### PR TITLE
Codex/pytest ci foundation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,11 @@
-name: Tests
+name: CI
 
 on:
   push:
   pull_request:
 
 jobs:
-  pytest:
+  checks:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -20,6 +20,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[test]"
+
+      - name: Run Ruff
+        run: ruff check .
+
+      - name: Run Black
+        run: black --check .
 
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ When running MultiSuSiE on binary traits, we recommend providing `b_list`, `s_li
 ## Questions?
 
 Feel free to open an issue on GitHub (preferred) or email jordanerossen@gmail.com.
+
+## Development checks
+
+To run the same quality checks locally that run in CI:
+
+```bash
+pip install -e ".[test]"
+ruff check .
+pytest -q
+```

--- a/examples/example_for_install_script.py
+++ b/examples/example_for_install_script.py
@@ -1,75 +1,94 @@
 import MultiSuSiE
 import numpy as np
 
-print('Testing MultiSuSiE installation...')
-print('Loading genotypes and creating simulated phenotypes')
+print("Testing MultiSuSiE installation...")
+print("Loading genotypes and creating simulated phenotypes")
 
-geno_YRI = np.loadtxt('MultiSuSiE/example_data/geno_YRI.txt')
-geno_CEU = np.loadtxt('MultiSuSiE/example_data/geno_CEU.txt')
-geno_JPT = np.loadtxt('MultiSuSiE/example_data/geno_JPT.txt')
+geno_YRI = np.loadtxt("MultiSuSiE/example_data/geno_YRI.txt")
+geno_CEU = np.loadtxt("MultiSuSiE/example_data/geno_CEU.txt")
+geno_JPT = np.loadtxt("MultiSuSiE/example_data/geno_JPT.txt")
 geno_list = [geno_YRI, geno_CEU, geno_JPT]
 
 beta_YRI = np.zeros(40)
 beta_CEU = np.zeros(40)
 beta_JPT = np.zeros(40)
-beta_YRI[10]=.75
-beta_CEU[10]=1
-beta_JPT[10]=.5
-beta_YRI[3]=.5
-beta_CEU[3]=.5
-beta_JPT[3]=.5
-beta_YRI[38]=1
-beta_CEU[38]=0
-beta_JPT[38]=0
+beta_YRI[10] = 0.75
+beta_CEU[10] = 1
+beta_JPT[10] = 0.5
+beta_YRI[3] = 0.5
+beta_CEU[3] = 0.5
+beta_JPT[3] = 0.5
+beta_YRI[38] = 1
+beta_CEU[38] = 0
+beta_JPT[38] = 0
 beta_list = [beta_YRI, beta_CEU, beta_JPT]
 
 rng = np.random.default_rng(2)
-y_list = [geno.dot(beta) + rng.standard_normal(geno.shape[0]) for (geno, beta) in zip(geno_list, beta_list)]
+y_list = [
+    geno.dot(beta) + rng.standard_normal(geno.shape[0])
+    for (geno, beta) in zip(geno_list, beta_list)
+]
 y_list = [y - np.mean(y) for y in y_list]
 
 XTY_list = [geno.T.dot(y) for (geno, y) in zip(geno_list, y_list)]
 XTX_diagonal_list = [np.diagonal(geno.T.dot(geno)) for geno in geno_list]
-with np.errstate(divide='ignore',invalid='ignore'): # just to silence a divide by zero error
-    beta_hat_list = [XTY / XTX_diag for (XTY, XTX_diag) in zip(XTY_list, XTX_diagonal_list)]
+with np.errstate(
+    divide="ignore", invalid="ignore"
+):  # just to silence a divide by zero error
+    beta_hat_list = [
+        XTY / XTX_diag for (XTY, XTX_diag) in zip(XTY_list, XTX_diagonal_list)
+    ]
 
 N_list = [geno.shape[0] for geno in geno_list]
-residuals_list = [np.expand_dims(y, 1) - (geno * beta) for (y, geno, beta) in zip(y_list, geno_list, beta_hat_list)]
-sum_of_squared_residuals_list = [np.sum(resid ** 2, axis = 0) for resid in residuals_list]
-se_list = [np.sqrt(ssr / ((N - 2) * XTX)) for (ssr, N, XTX) in zip(sum_of_squared_residuals_list, N_list, XTX_diagonal_list)]
+residuals_list = [
+    np.expand_dims(y, 1) - (geno * beta)
+    for (y, geno, beta) in zip(y_list, geno_list, beta_hat_list)
+]
+sum_of_squared_residuals_list = [np.sum(resid**2, axis=0) for resid in residuals_list]
+se_list = [
+    np.sqrt(ssr / ((N - 2) * XTX))
+    for (ssr, N, XTX) in zip(sum_of_squared_residuals_list, N_list, XTX_diagonal_list)
+]
 
-with np.errstate(divide='ignore',invalid='ignore'): # just to silence a divide by zero error
-    R_list = [np.corrcoef(geno, rowvar = False) for geno in geno_list]
+with np.errstate(
+    divide="ignore", invalid="ignore"
+):  # just to silence a divide by zero error
+    R_list = [np.corrcoef(geno, rowvar=False) for geno in geno_list]
 
 YTY_list = [y.dot(y) for y in y_list]
-varY_list = [np.var(y, ddof = 1) for y in y_list]
+varY_list = [np.var(y, ddof=1) for y in y_list]
 
-z_list = [b/s for (b,s) in zip(beta_hat_list, se_list)]
+z_list = [b / s for (b, s) in zip(beta_hat_list, se_list)]
 
-print('Running MultiSuSiE with summary statistics')
+print("Running MultiSuSiE with summary statistics")
 
 ss_fit = MultiSuSiE.multisusie_rss(
-    b_list = beta_hat_list,
-    s_list = se_list,
-    R_list = R_list,
-    varY_list = varY_list,
-    rho = np.array([[1, 0.75, 0.75], [0.75, 1, 0.75], [0.75, 0.75, 1]]),
-    population_sizes = N_list,
-    L = 10,
-    low_memory_mode = False,
-    recover_R = False,
-    float_type = np.float64,
-    single_population_mac_thresh = 0,
+    b_list=beta_hat_list,
+    s_list=se_list,
+    R_list=R_list,
+    varY_list=varY_list,
+    rho=np.array([[1, 0.75, 0.75], [0.75, 1, 0.75], [0.75, 0.75, 1]]),
+    population_sizes=N_list,
+    L=10,
+    low_memory_mode=False,
+    recover_R=False,
+    float_type=np.float64,
+    single_population_mac_thresh=0,
 )
 
-print('Running MultiSuSiE with individual level data')
+print("Running MultiSuSiE with individual level data")
 
 indiv_fit = MultiSuSiE.multisusie(
-    X_list = [g + 1 for g in geno_list],
-    Y_list = y_list,
-    rho = np.array([[1, 0.75, 0.75], [0.75, 1, 0.75], [0.75, 0.75, 1]]),
-    L = 10,
-    standardize = False,
-    float_type = np.float64
+    X_list=[g + 1 for g in geno_list],
+    Y_list=y_list,
+    rho=np.array([[1, 0.75, 0.75], [0.75, 1, 0.75], [0.75, 0.75, 1]]),
+    L=10,
+    standardize=False,
+    float_type=np.float64,
 )
-print('Summary statistic and individual level fine-mapping have been run successfully')
-print('The maximum difference in PIP between the two methods is {}. This number should be close to zero'.format(np.max(np.abs(ss_fit.pip - indiv_fit.pip))))
+print("Summary statistic and individual level fine-mapping have been run successfully")
+print(
+    "The maximum difference in PIP between the two methods is {}. This number should be close to zero".format(
+        np.max(np.abs(ss_fit.pip - indiv_fit.pip))
+    )
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,19 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    'pytest'
+    'pytest',
+    'ruff',
+    'black'
 ]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
+[tool.ruff.lint]
+# Start with high-signal correctness checks and expand gradually.
+select = ["E9", "F63", "F7", "F82"]
+
+[tool.black]
+line-length = 88
+target-version = ['py311']

--- a/src/MultiSuSiE/__init__.py
+++ b/src/MultiSuSiE/__init__.py
@@ -1,2 +1,8 @@
-from .susiepy_ss import multisusie_rss, recover_XTX_and_XTY, recover_R_from_XTX, susie_multi_rss, recover_XTX_and_XTY_from_Z
+from .susiepy_ss import (
+    multisusie_rss,
+    recover_XTX_and_XTY,
+    recover_R_from_XTX,
+    susie_multi_rss,
+    recover_XTX_and_XTY_from_Z,
+)
 from .susiepy import multisusie, susie_multi

--- a/src/MultiSuSiE/susiepy.py
+++ b/src/MultiSuSiE/susiepy.py
@@ -1,11 +1,9 @@
-import numpy as np; np.set_printoptions(precision=3)
+import numpy as np
 from tqdm import tqdm #
 import scipy.stats as stats
-import scipy.linalg as la
 import logging
 import time
 import sys
-from scipy.optimize import minimize_scalar
 from . import susiepy_ss
 
 #TODO:
@@ -85,7 +83,7 @@ def multisusie(
     ----------
     X_list: Length K list of numpy arrays, one for each population. Rows correspond
         to samples and the columns correspond to variants. Each array should
-        contain the same set of variants in the same order. Its fine if 
+        contain the same set of variants in the same order. It's fine if 
         some columns are constant. 
     Y_list: Length K list of one dimensional numpy arrays, one for each population. 
         Rows correspond to samples. Samples should be in the same order as in 
@@ -101,7 +99,7 @@ def multisusie(
         and estimate_prior_method is not set to None.
     prior_weights: numpy P-array of floats representing the prior probability
         of causality for each variant. Give None to use a uniform prior
-    standardize: boolnea, whether to standardize the genotypes to have
+    standardize: boolean, whether to standardize the genotypes to have
         variance of 1.
     residual_variance: Length K numpy array of floats representing the residual
         variance for each population.
@@ -122,7 +120,7 @@ def multisusie(
     residual_variance_upperbound: float, upper bound on the residual variance
     residual_variance_lowerbound: float, lower bound on the residual variance
     tol: float, after iter_before_zeroing_effects iterations, results
-        are returned if the ELBO increases by less than tol in an ieration
+        are returned if the ELBO increases by less than tol in an iteration
     verbose: boolean which indicates if the objective function should be printed
     coverage: float representing the minimum coverage of credible sets
     min_abs_corr: float representing the minimum absolute correlation between
@@ -159,13 +157,17 @@ def multisusie(
               'WILL BE STANDARDIZED IN PLACE AND CHANGED.')
 
     #check input
-    assert len(X_list) == len(Y_list)
-    assert np.all([X.shape[1] == X_list[0].shape[1] for X in X_list])
-    assert np.all([X.shape[0] == Y.shape[0] for X,Y in zip(X_list, Y_list)])
+    if len(X_list) != len(Y_list):
+        raise ValueError("X_list and Y_list must have the same length")
+    if not np.all([X.shape[1] == X_list[0].shape[1] for X in X_list]):
+        raise ValueError("all matrices in X_list must have the same number of columns")
+    if not np.all([X.shape[0] == Y.shape[0] for X, Y in zip(X_list, Y_list)]):
+        raise ValueError("each X_list[i] and Y_list[i] must have the same number of rows")
     if prior_weights is not None:
         prior_weights = prior_weights.astype(float_type)
     
-    assert not np.any([np.any(np.isnan(X)) for X in X_list])
+    if np.any([np.any(np.isnan(X)) for X in X_list]):
+        raise ValueError("X_list must not contain NaN values")
     
     #remove missing individuals
     for i in range(len(X_list)):
@@ -184,7 +186,8 @@ def multisusie(
     #compute rho properties
     rho = rho.astype(float_type)
     logdet_rho_sign, logdet_rho = np.linalg.slogdet(rho)
-    assert logdet_rho_sign>0
+    if logdet_rho_sign <= 0:
+        raise ValueError("rho must be positive definite")
 
     #compute X mean and std
     cm_arr = np.array([X.mean(axis=0) for X in X_list], dtype=float_type)
@@ -213,7 +216,8 @@ def multisusie(
         
     
     #create a C-contiguous version of X
-    assert np.all([X.flags['F_CONTIGUOUS'] == X_std_list[0].flags['F_CONTIGUOUS'] for X in X_std_list])
+    if not np.all([X.flags['F_CONTIGUOUS'] == X_std_list[0].flags['F_CONTIGUOUS'] for X in X_std_list]):
+        raise ValueError("all matrices in X_list must have consistent memory layout")
     if X_std_list[0].flags['F_CONTIGUOUS']:
         for i in range(len(X_std_list)):
             X_std_list[i] = np.ascontiguousarray(X_std_list[i])
@@ -229,15 +233,16 @@ def multisusie(
     p = X_list[0].shape[1]
     varY = np.concatenate(Y_list).var(ddof=1)
     varY_list = [Y.var(ddof=1) for Y in Y_list]
-    if np.isscalar(scaled_prior_variance):
-        assert 0 < scaled_prior_variance <= 1
+    if np.isscalar(scaled_prior_variance) and not (0 < scaled_prior_variance <= 1):
+        raise ValueError("scaled_prior_variance must be in (0, 1] when scalar")
     if residual_variance is None:
         residual_variance = np.array(varY_list, dtype=float_type)
     if prior_weights is None:
         prior_weights = np.zeros(p, dtype=float_type) + 1.0/p
     else:
         prior_weights = (prior_weights / np.sum(prior_weights)).astype(float_type)
-    assert prior_weights.shape[0] == p
+    if prior_weights.shape[0] != p:
+        raise ValueError("prior_weights must have length equal to the number of variants")
     if p<L: L=p
     s = S(X_std_list, L, scaled_prior_variance, residual_variance, varY, prior_weights, float_type = float_type)
     elbo = np.zeros(max_iter+1) + np.nan

--- a/src/MultiSuSiE/susiepy.py
+++ b/src/MultiSuSiE/susiepy.py
@@ -1,81 +1,89 @@
 import numpy as np
-from tqdm import tqdm #
+from tqdm import tqdm
 import scipy.stats as stats
 import logging
 import time
 import sys
 from . import susiepy_ss
 
-#TODO:
+# TODO:
 # - implement early_EM
 
 
 class S:
-    def __init__(self, X_std_list, L, scaled_prior_variance, residual_variance, varY, prior_weights, float_type):
-        
-        #code from init_setup
+    def __init__(
+        self,
+        X_std_list,
+        L,
+        scaled_prior_variance,
+        residual_variance,
+        varY,
+        prior_weights,
+        float_type,
+    ):
+
+        # code from init_setup
         num_pop = len(X_std_list)
         p = X_std_list[0].shape[1]
-        self.alpha = np.zeros((L, p), dtype=float_type) + 1.0/p
+        self.alpha = np.zeros((L, p), dtype=float_type) + 1.0 / p
         self.mu = np.zeros((num_pop, L, p), dtype=float_type)
-        #self.mu2 = np.zeros((num_pop, L, p), dtype=float_type)
         self.mu2 = np.zeros((num_pop, num_pop, L, p), dtype=float_type)
         self.Xr_list = [np.zeros(X.shape[0], dtype=float_type) for X in X_std_list]
         self.sigma2 = residual_variance.astype(float_type)
-        ###assert np.isscalar(self.sigma2)
         self.pi = prior_weights.astype(float_type)
         self.n = np.array([X.shape[0] for X in X_std_list])
-        
-        #code from init_finalize
+
+        # code from init_finalize
         self.V = scaled_prior_variance * varY + np.zeros((num_pop, L), dtype=float_type)
         self.V = self.V.astype(float_type)
         assert np.all(self.V >= 0)
         self.KL = np.zeros(L, dtype=float_type) + np.nan
         self.lbf = np.zeros(L, dtype=float_type) + np.nan
-        
+
         self.converged = False
 
+
 class SER_RESULTS:
-            def __init__(self, alpha, mu, mu2, lbf, lbf_model, V, loglik):
-                self.alpha = alpha
-                self.mu = mu
-                self.mu2 = mu2
-                self.lbf = lbf
-                self.lbf_model = lbf_model
-                self.V = V
-                self.loglik = loglik
+    def __init__(self, alpha, mu, mu2, lbf, lbf_model, V, loglik):
+        self.alpha = alpha
+        self.mu = mu
+        self.mu2 = mu2
+        self.lbf = lbf
+        self.lbf_model = lbf_model
+        self.V = V
+        self.loglik = loglik
+
 
 def multisusie(
-    X_list, 
-    Y_list, 
-    rho, 
-    L,
-    scaled_prior_variance = 0.2,
-    prior_weights = None,
-    standardize = False,
-    residual_variance = None, 
-    estimate_residual_variance = True,
-    estimate_prior_variance = True,
-    estimate_prior_method = 'early_EM',
-    pop_spec_effect_priors = True,
-    iter_before_zeroing_effects = 5,
-    prior_tol = 1e-9,
-    max_iter = 100,
-    residual_variance_upperbound = np.inf,
-    residual_variance_lowerbound = 0,
-    tol = 1e-3,
-    verbose = False,
-    coverage = 0.95,
-    min_abs_corr = 0,
-    check_null_threshold = 0,
-    float_type = np.float64,
-    low_memory_mode = False,
-    calculate_purity = True,
-    n_purity = 100,
-    variant_ids = None
-    ):
-
-    """ Top-level function for running MultiSuSiE with individual level data
+    X_list: list[np.ndarray],
+    Y_list: list[np.ndarray],
+    rho: np.ndarray,
+    L: int,
+    scaled_prior_variance: float | np.ndarray = 0.2,
+    prior_weights: np.ndarray | None = None,
+    standardize: bool = False,
+    residual_variance: np.ndarray | None = None,
+    estimate_residual_variance: bool = True,
+    estimate_prior_variance: bool = True,
+    estimate_prior_method: str | None = "early_EM",
+    pop_spec_effect_priors: bool = True,
+    iter_before_zeroing_effects: int = 5,
+    prior_tol: float = 1e-9,
+    max_iter: int = 100,
+    residual_variance_upperbound: float = np.inf,
+    residual_variance_lowerbound: float = 0,
+    tol: float = 1e-3,
+    verbose: bool = False,
+    coverage: float = 0.95,
+    min_abs_corr: float = 0,
+    check_null_threshold: float = 0,
+    float_type: type = np.float64,
+    low_memory_mode: bool = False,
+    calculate_purity: bool = True,
+    n_purity: int = 100,
+    variant_ids: list[str] | None = None,
+) -> S:
+    """Top-level function for running MultiSuSiE with individual level data
 
     This function takes genotype and phenotype matrices and runs MultiSuSiE on them
 
@@ -83,18 +91,19 @@ def multisusie(
     ----------
     X_list: Length K list of numpy arrays, one for each population. Rows correspond
         to samples and the columns correspond to variants. Each array should
-        contain the same set of variants in the same order. It's fine if 
-        some columns are constant. 
-    Y_list: Length K list of one dimensional numpy arrays, one for each population. 
-        Rows correspond to samples. Samples should be in the same order as in 
-        X_list. 
-    rho: PxP numpy array representing the effect size correlation matrix (P is the
-        number of variants). In the manuscript, we show that this parameter has 
-        little impact on the estimated PIPs in practice.
+        contain the same set of variants in the same order. It's fine if
+        some columns are constant.
+    Y_list: Length K list of one dimensional numpy arrays, one for each population.
+        Rows correspond to samples. Samples should be in the same order as in
+        X_list.
+    rho: KxK numpy array representing the cross-population effect size
+        correlation matrix (K is the number of populations). In the manuscript,
+        we show that this parameter has little impact on the estimated PIPs in
+        practice.
     L: integer representing the maximum number of causal variants
     scaled_prior_variance: float representing the effect size prior variance,
-        scaled by the residual variance. It's fine to set this to a number 
-        larger than what you expect the squared effect size to be (like the 
+        scaled by the residual variance. It's fine to set this to a number
+        larger than what you expect the squared effect size to be (like the
         default value of 0.2) as long as estimate_prior_variance is set to True
         and estimate_prior_method is not set to None.
     prior_weights: numpy P-array of floats representing the prior probability
@@ -108,11 +117,11 @@ def multisusie(
         $A^{(l)}$ in the manuscript
     estimate_prior_method: string, method to estimate the prior variance. Recommended
         values are 'early_EM' or None
-    pop_spec_effect_priors: boolean, whether to estimate separate prior 
+    pop_spec_effect_priors: boolean, whether to estimate separate prior
         variance parameters for each population
     iter_before_zeroing_effects: integer, number of iterations to run before
-        zeroing out component-population pairs (or components if 
-        pop_spec_effect_priors is False) that have a lower likelihood than a 
+        zeroing out component-population pairs (or components if
+        pop_spec_effect_priors is False) that have a lower likelihood than a
         null model
     prior_tol: float which places a filter on the minimum prior variance
         for a component to be included when estimating PIPs
@@ -132,17 +141,17 @@ def multisusie(
     float_type: numpy float type used. Set to np.float32 to minimize memory
         consumption.
     low_memory_mode: boolean, if True, the input X_list arrays will be modified
-        in place during standardization to reduce memory use. BUT, THE INPUT
-        GENOTYPE MATRICES IN X_list WILL BE CHANGED. If you need X_list
-        unchanged after this call, set low_memory_mode to False.
+        in place during standardization to reduce memory use. This can change
+        the provided numpy arrays after multisusie is complete. If you need
+        X_list unchanged after this call, set low_memory_mode to False.
     calculate_purity: boolean, whether to calculate credible set purity.
         If False, purity values in the returned sets are not computed.
     n_purity: integer, maximum number of variants to use when computing purity.
         If a credible set contains more than n_purity variants, a random subset
         of size n_purity is used for purity calculations.
-    variant_ids: length P list of strings representing the variant IDs. If 
+    variant_ids: length P list of strings representing the variant IDs. If
         provided, sets will contain a fifth entry, containing the variant ids
-        of the variants contained in each set. 
+        of the variants contained in each set.
 
     """
 
@@ -153,43 +162,47 @@ def multisusie(
         X_list = list(X_list)
         Y_list = list(Y_list)
     else:
-        print('low memory mode is on. THE INPUT GENOTYPE MATRICES IN X_list ' +
-              'WILL BE STANDARDIZED IN PLACE AND CHANGED.')
+        print(
+            "low memory mode is on. THE INPUT GENOTYPE MATRICES IN X_list "
+            + "WILL BE STANDARDIZED IN PLACE AND CHANGED."
+        )
 
-    #check input
+    # check input
     if len(X_list) != len(Y_list):
         raise ValueError("X_list and Y_list must have the same length")
     if not np.all([X.shape[1] == X_list[0].shape[1] for X in X_list]):
         raise ValueError("all matrices in X_list must have the same number of columns")
     if not np.all([X.shape[0] == Y.shape[0] for X, Y in zip(X_list, Y_list)]):
-        raise ValueError("each X_list[i] and Y_list[i] must have the same number of rows")
+        raise ValueError(
+            "each X_list[i] and Y_list[i] must have the same number of rows"
+        )
     if prior_weights is not None:
         prior_weights = prior_weights.astype(float_type)
-    
+
     if np.any([np.any(np.isnan(X)) for X in X_list]):
         raise ValueError("X_list must not contain NaN values")
-    
-    #remove missing individuals
+
+    # remove missing individuals
     for i in range(len(X_list)):
         if np.any(np.isnan(Y_list[i])):
             X_list[i] = X_list[i][~np.isnan(Y_list[i])]
             Y_list[i] = Y_list[i][~np.isnan(Y_list[i])]
-        
-    #center Y
+
+    # center Y
     mean_y_list = [Y.mean() for Y in Y_list]
-    Y_list = [Y-mean_Y for Y,mean_Y in zip(Y_list, mean_y_list)]
-        
-    #compute w_pop (the relative size of each population)
+    Y_list = [Y - mean_Y for Y, mean_Y in zip(Y_list, mean_y_list)]
+
+    # compute w_pop (the relative size of each population)
     n_arr = np.array([X.shape[0] for X in X_list], dtype=int)
     w_pop = (n_arr / n_arr.sum()).astype(float_type)
 
-    #compute rho properties
+    # compute rho properties
     rho = rho.astype(float_type)
     logdet_rho_sign, logdet_rho = np.linalg.slogdet(rho)
     if logdet_rho_sign <= 0:
         raise ValueError("rho must be positive definite")
 
-    #compute X mean and std
+    # compute X mean and std
     cm_arr = np.array([X.mean(axis=0) for X in X_list], dtype=float_type)
     if standardize:
         csd_arr = np.array([X.std(axis=0, ddof=1) for X in X_list], dtype=float_type)
@@ -197,8 +210,7 @@ def multisusie(
     else:
         csd = np.ones(X_list[0].shape[1], dtype=float_type)
 
-        
-    #Standardize X
+    # Standardize X
     is_constant_column = np.isclose(csd, 0.0)
     csd[is_constant_column] = 1.0
     if low_memory_mode:
@@ -207,29 +219,33 @@ def multisusie(
             X_std_list[pop_i] -= cm_arr[pop_i]
             X_std_list[pop_i] /= csd
     else:
-        X_std_list = [(X-cm)/csd for X,cm in zip(X_list, cm_arr)]
-    
-    #explicitly mark that constant columns are zero
+        X_std_list = [(X - cm) / csd for X, cm in zip(X_list, cm_arr)]
+
+    # explicitly mark that constant columns are zero
     if np.any(is_constant_column):
         for i in range(len(X_std_list)):
             X_std_list[i][:, is_constant_column] = 0.0
-        
-    
-    #create a C-contiguous version of X
-    if not np.all([X.flags['F_CONTIGUOUS'] == X_std_list[0].flags['F_CONTIGUOUS'] for X in X_std_list]):
+
+    # create a C-contiguous version of X
+    if not np.all(
+        [
+            X.flags["F_CONTIGUOUS"] == X_std_list[0].flags["F_CONTIGUOUS"]
+            for X in X_std_list
+        ]
+    ):
         raise ValueError("all matrices in X_list must have consistent memory layout")
-    if X_std_list[0].flags['F_CONTIGUOUS']:
+    if X_std_list[0].flags["F_CONTIGUOUS"]:
         for i in range(len(X_std_list)):
             X_std_list[i] = np.ascontiguousarray(X_std_list[i])
-        
-    
-    X_l2_arr = np.array([np.einsum('ij,ij->j', X_std, X_std) for X_std in X_std_list], dtype=float_type)
-    
-    
-    #compute rho properties
+
+    X_l2_arr = np.array(
+        [np.einsum("ij,ij->j", X_std, X_std) for X_std in X_std_list], dtype=float_type
+    )
+
+    # compute rho properties
     rho = rho.astype(float_type)
-    
-    #init setup
+
+    # init setup
     p = X_list[0].shape[1]
     varY = np.concatenate(Y_list).var(ddof=1)
     varY_list = [Y.var(ddof=1) for Y in Y_list]
@@ -238,27 +254,37 @@ def multisusie(
     if residual_variance is None:
         residual_variance = np.array(varY_list, dtype=float_type)
     if prior_weights is None:
-        prior_weights = np.zeros(p, dtype=float_type) + 1.0/p
+        prior_weights = np.zeros(p, dtype=float_type) + 1.0 / p
     else:
         prior_weights = (prior_weights / np.sum(prior_weights)).astype(float_type)
     if prior_weights.shape[0] != p:
-        raise ValueError("prior_weights must have length equal to the number of variants")
-    if p<L: L=p
-    s = S(X_std_list, L, scaled_prior_variance, residual_variance, varY, prior_weights, float_type = float_type)
-    elbo = np.zeros(max_iter+1) + np.nan
+        raise ValueError(
+            "prior_weights must have length equal to the number of variants"
+        )
+    if p < L:
+        L = p
+    s = S(
+        X_std_list,
+        L,
+        scaled_prior_variance,
+        residual_variance,
+        varY,
+        prior_weights,
+        float_type=float_type,
+    )
+    elbo = np.zeros(max_iter + 1) + np.nan
     elbo[0] = -np.inf
-    
-    
+
     ### start iterations ###
     tqdm_iter = tqdm(list(range(max_iter)), disable=not verbose, file=sys.stdout)
     for i in tqdm_iter:
-        tqdm_iter.set_description('iteration %d/%d'%(i+1, max_iter))
+        tqdm_iter.set_description("iteration %d/%d" % (i + 1, max_iter))
 
-        if estimate_prior_method == 'early_EM':
-            if i == 0: 
+        if estimate_prior_method == "early_EM":
+            if i == 0:
                 current_estimate_prior_method = None
             else:
-                current_estimate_prior_method = 'early_EM'
+                current_estimate_prior_method = "early_EM"
         else:
             current_estimate_prior_method = estimate_prior_method
 
@@ -268,64 +294,91 @@ def multisusie(
             current_check_null_threshold = check_null_threshold
 
         s = update_each_effect(
-            X_std_list = X_std_list, Y_list = Y_list, s = s, X_l2_arr = X_l2_arr, 
-            w_pop = w_pop, rho = rho, estimate_prior_variance = estimate_prior_variance, 
-            estimate_prior_method = current_estimate_prior_method, verbose=verbose,
-            float_type = float_type, pop_spec_effect_priors = pop_spec_effect_priors,
-            check_null_threshold = current_check_null_threshold
+            X_std_list=X_std_list,
+            Y_list=Y_list,
+            s=s,
+            X_l2_arr=X_l2_arr,
+            w_pop=w_pop,
+            rho=rho,
+            estimate_prior_variance=estimate_prior_variance,
+            estimate_prior_method=current_estimate_prior_method,
+            verbose=verbose,
+            float_type=float_type,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            check_null_threshold=current_check_null_threshold,
         )
 
-        #compute objective before updating residual variance
-        #because part of the objective s.kl has already been computed
-        #under the residual variance before the update
-        elbo[i+1] = get_objective(X_std_list, Y_list, s, X_l2_arr)
+        # compute objective before updating residual variance
+        # because part of the objective s.kl has already been computed
+        # under the residual variance before the update
+        elbo[i + 1] = get_objective(X_std_list, Y_list, s, X_l2_arr)
         if verbose:
-            logging.info('objective: %s'%(elbo[i+1]))
-            print('objective: %s'%(elbo[i+1]))
-        
-        if (elbo[i+1] - elbo[i]) < tol:
+            logging.info("objective: %s" % (elbo[i + 1]))
+            print("objective: %s" % (elbo[i + 1]))
+
+        if (elbo[i + 1] - elbo[i]) < tol:
             s.converged = True
             tqdm_iter.close()
             break
-        
-        if estimate_residual_variance:
-            s.sigma2 = estimate_residual_variance_func(X_std_list, Y_list, s, X_l2_arr, float_type)
-            s.sigma2 = np.minimum(s.sigma2, residual_variance_upperbound).astype(float_type)
-            s.sigma2 = np.maximum(s.sigma2, residual_variance_lowerbound).astype(float_type)
-        if verbose:
-            logging.info('objective after updating sigma2: %s'%(get_objective(X_std_list, Y_list, s, X_l2_arr)))
-    
-    elbo = elbo[1:i+2] # Remove first (infinite) entry, and trailing NAs.
-    s.elbo = elbo
-    s.niter = i+1
 
-    if verbose: 
-        logging.info('done in %0.2f seconds'%(time.time() - t0))
-        logging.info(f'elbo: {elbo[~np.isnan(elbo)]}')
+        if estimate_residual_variance:
+            s.sigma2 = estimate_residual_variance_func(
+                X_std_list, Y_list, s, X_l2_arr, float_type
+            )
+            s.sigma2 = np.minimum(s.sigma2, residual_variance_upperbound).astype(
+                float_type
+            )
+            s.sigma2 = np.maximum(s.sigma2, residual_variance_lowerbound).astype(
+                float_type
+            )
+        if verbose:
+            logging.info(
+                "objective after updating sigma2: %s"
+                % (get_objective(X_std_list, Y_list, s, X_l2_arr))
+            )
+
+    elbo = elbo[1 : i + 2]  # Remove first (infinite) entry, and trailing NAs.
+    s.elbo = elbo
+    s.niter = i + 1
+
+    if verbose:
+        logging.info("done in %0.2f seconds" % (time.time() - t0))
+        logging.info(f"elbo: {elbo[~np.isnan(elbo)]}")
     if not s.converged:
-        logging.info('IBSS algorithm did not converge in %d iterations'%(max_iter))
+        logging.info("IBSS algorithm did not converge in %d iterations" % (max_iter))
     else:
-        logging.info('IBSS algorithm converged in %d iterations'%(i))
-        
-    #zero out everything related to constant variables, just to be on the safe side
+        logging.info("IBSS algorithm converged in %d iterations" % (i))
+
+    # zero out everything related to constant variables, just to be on the safe side
     if np.any(is_constant_column):
         s.mu[:, :, is_constant_column] = 0.0
         s.mu2[:, :, :, is_constant_column] = 0.0
         s.alpha[:, is_constant_column] = 0.0
-        
+
     s.intercept = np.zeros(len(X_list))
     s.fitted = s.Xr_list
-        
-    s.pip = susie_get_pip(s, prior_tol=prior_tol)    
+
+    s.pip = susie_get_pip(s, prior_tol=prior_tol)
     s.X_column_scale_factors = csd.copy()
     s.X_column_scale_factors[is_constant_column] = 0.0
-    s.coef = np.array([np.sum(s.mu[k] * s.alpha, axis=0) / csd for k in range(len(Y_list))])
-    s.coef_sd = np.array([(np.sqrt(np.sum(s.alpha * s.mu2[k, k] - (s.alpha*s.mu[k])**2, axis=0)) / csd) for k in range(len(Y_list))])
+    s.coef = np.array(
+        [np.sum(s.mu[k] * s.alpha, axis=0) / csd for k in range(len(Y_list))]
+    )
+    coef_sd_list = []
+    for k in range(len(Y_list)):
+        var_k = np.sum(s.alpha * s.mu2[k, k] - (s.alpha * s.mu[k]) ** 2, axis=0)
+        coef_sd_list.append(np.sqrt(var_k) / csd)
+    s.coef_sd = np.array(coef_sd_list)
 
     s.sets = susiepy_ss.susie_get_cs(
-        s, R_list = None, coverage = coverage, min_abs_corr = min_abs_corr,
-        dedup = True, n_purity = n_purity, calculate_purity = calculate_purity,
-        X_list = X_std_list
+        s,
+        R_list=None,
+        coverage=coverage,
+        min_abs_corr=min_abs_corr,
+        dedup=True,
+        n_purity=n_purity,
+        calculate_purity=calculate_purity,
+        X_list=X_std_list,
     )
 
     s.variant_ids = variant_ids
@@ -339,46 +392,75 @@ def multisusie(
 
 
 def get_ER2(X_std, Y, alpha, mu, mu2, Xr, X_l2):
-    """ expected squared residuals
-    """
-    Xr_L = X_std.dot((alpha*mu).T)
-    postb2 = alpha*mu2
+    """expected squared residuals"""
+    Xr_L = X_std.dot((alpha * mu).T)
+    postb2 = alpha * mu2
     r = Y - Xr
-    result = r.dot(r) - np.einsum('ij,ij->',Xr_L, Xr_L) + np.sum(X_l2.dot(postb2.T))
-    return result     
+    result = r.dot(r) - np.einsum("ij,ij->", Xr_L, Xr_L) + np.sum(X_l2.dot(postb2.T))
+    return result
+
 
 def SER_posterior_e_loglik(X_std_list, Y_list, s2, Eb, Eb2, X_l2_arr, n):
-    """ posterior expected loglikelihood for a SER (Eq B.6 - B.9 (after expanding the L2-norm))
+    """posterior expected loglikelihood for a SER (Eq B.6 - B.9 (after expanding the L2-norm))
 
     Eb the posterior mean of b (p vector) (alpha * mu)
     Eb2 the posterior second moment of b (p vector) (alpha * mu2)
     """
-    result = -0.5 * n.dot(np.log(2*np.pi*s2))
+    result = -0.5 * n.dot(np.log(2 * np.pi * s2))
     for i in range(len(Y_list)):
         Y = Y_list[i]
         X_std = X_std_list[i]
-        result -= 0.5/s2[i] * (Y.dot(Y) - 2*Y.dot(X_std.dot(Eb[i])) + X_l2_arr[i].dot(Eb2[i]))
-        #result -= 0.5/s2[i] * (np.sum(Y * Y) - 2*Y.dot(X_std.dot(Eb[i])) + X_l2_arr[i].dot(Eb2[i]))
-        #result -= 0.5/s2[i] * (np.sum(Y * Y) - 2*Y.dot(X_std.dot(Eb[i])) + np.sum(X_l2_arr[i] * Eb2[i]))
+        result -= (
+            0.5
+            / s2[i]
+            * (Y.dot(Y) - 2 * Y.dot(X_std.dot(Eb[i])) + X_l2_arr[i].dot(Eb2[i]))
+        )
+        # result -= 0.5/s2[i] * (np.sum(Y * Y) - 2*Y.dot(X_std.dot(Eb[i])) + X_l2_arr[i].dot(Eb2[i]))
+        # result -= 0.5/s2[i] * (np.sum(Y * Y) - 2*Y.dot(X_std.dot(Eb[i])) + np.sum(X_l2_arr[i] * Eb2[i]))
     return result
 
 
 def Eloglik(X_std_list, Y_list, s, X_l2_arr):
-    """expected log-likelihood for a susie fit
-    """
-    result = -0.5 * s.n.dot(np.log(2*np.pi*s.sigma2))
+    """expected log-likelihood for a susie fit"""
+    result = -0.5 * s.n.dot(np.log(2 * np.pi * s.sigma2))
     for i in range(len(Y_list)):
-        result -= 0.5/s.sigma2[i] * get_ER2(X_std_list[i], Y_list[i], s.alpha, s.mu[i], s.mu2[i, i], s.Xr_list[i], X_l2_arr[i])
+        result -= (
+            0.5
+            / s.sigma2[i]
+            * get_ER2(
+                X_std_list[i],
+                Y_list[i],
+                s.alpha,
+                s.mu[i],
+                s.mu2[i, i],
+                s.Xr_list[i],
+                X_l2_arr[i],
+            )
+        )
     return result
+
 
 def get_objective(X_std_list, Y_list, s, X_l2_arr):
     return Eloglik(X_std_list, Y_list, s, X_l2_arr) - np.sum(s.KL)
 
+
 def estimate_residual_variance_func(X_std_list, Y_list, s, X_l2_arr, float_type):
     sigma2_arr = np.zeros(len(Y_list), dtype=float_type)
     for i in range(len(Y_list)):
-        sigma2_arr[i] =  get_ER2(X_std_list[i], Y_list[i], s.alpha, s.mu[i], s.mu2[i, i], s.Xr_list[i], X_l2_arr[i]) / s.n[i]
+        sigma2_arr[i] = (
+            get_ER2(
+                X_std_list[i],
+                Y_list[i],
+                s.alpha,
+                s.mu[i],
+                s.mu2[i, i],
+                s.Xr_list[i],
+                X_l2_arr[i],
+            )
+            / s.n[i]
+        )
     return sigma2_arr
+
 
 def loglik_f(V, prior_weights, compute_lbf_params):
     lbf = compute_lbf(V, *compute_lbf_params)
@@ -389,69 +471,59 @@ def loglik_f(V, prior_weights, compute_lbf_params):
     loglik = maxlbf + np.log(weighted_sum_w)
     return loglik
 
-#def optimize_prior_variance(optimize_V, prior_weights, compute_lbf_params=None, alpha=None, post_mean2=None, w_pop=None, check_null_threshold=0, float_type = np.float64):
-#    
-#    if optimize_V == 'optim':
-#        if pop_spec_effect_priors:
-#            raise Exception('estimate_prior_method="optim" with ' +
-#        neg_loglik_logscale = lambda lV: -loglik_f(np.exp(lV), prior_weights, compute_lbf_params)
-#        opt_obj = minimize_scalar(neg_loglik_logscale, bounds=(-30,15))
-#        lV = opt_obj.x
-#        V = np.exp(lV)
-#    elif optimize_V == 'EM':
-#        V_arr = np.array([np.sum(alpha * post_mean2[i]) for i in range(post_mean2.shape[0])], dtype=float_type)
-#        if not pop_spec_effect_priors:
-#            V = (w_pop.dot(V_arr)).astype(float_type)
-#    else:
-#        raise ValueError('unknown optimization method')
-#        
-#    # set V exactly 0 if that beats the numerical value by check_null_threshold in loglik.
-#    #if check_null_threshold>0:
-#    if not pop_spec_effect_priors:
-#
-#    if loglik_f(0, prior_weights, compute_lbf_params) + check_null_threshold >= loglik_f(V, prior_weights, compute_lbf_params):
-#        V=0
-#    return V
-    
-def compute_lbf_1pop(V, X_std, Y, X_l2,
-        residual_variance,
-        return_moments=False,
-        verbose=False,
-        float_type = np.float64
-        ):
-    
+
+def compute_lbf_1pop(
+    V,
+    X_std,
+    Y,
+    X_l2,
+    residual_variance,
+    return_moments=False,
+    verbose=False,
+    float_type=np.float64,
+):
+
     Xty = Y.dot(X_std)
     betahat = np.zeros(Xty.shape[0], dtype=float_type)
     shat2 = np.zeros(Xty.shape[0], dtype=float_type)
     lbf = np.zeros(Xty.shape[0], dtype=float_type)
-    nz = (X_l2!=0)
+    nz = X_l2 != 0
     betahat[nz] = Xty[nz] / X_l2[nz]
     shat2[nz] = residual_variance / X_l2[nz]
-    lbf[nz] = stats.norm(0, np.sqrt(V+shat2[nz])).logpdf(betahat[nz]) - stats.norm(0, np.sqrt(shat2[nz])).logpdf(betahat[nz]) #equation A.3
-    if not return_moments: return lbf
-    
+    lbf[nz] = stats.norm(0, np.sqrt(V + shat2[nz])).logpdf(betahat[nz]) - stats.norm(
+        0, np.sqrt(shat2[nz])
+    ).logpdf(
+        betahat[nz]
+    )  # equation A.3
+    if not return_moments:
+        return lbf
+
     post_var = np.zeros((1, Xty.shape[0]), dtype=float_type)
     if not np.isclose(V, 0):
-        post_var[0,nz] = 1.0 / (1.0/V + 1.0/shat2[nz]) # posterior variance
-    post_mean = (1.0/residual_variance) * post_var * Xty
-    post_mean2 = post_var + post_mean**2 # second moment
+        post_var[0, nz] = 1.0 / (1.0 / V + 1.0 / shat2[nz])  # posterior variance
+    post_mean = (1.0 / residual_variance) * post_var * Xty
+    post_mean2 = post_var + post_mean**2  # second moment
 
     return lbf, post_mean, post_mean2
-    
-def compute_lbf(V, Y_list, X_std_list, X_l2_arr,
-        rho,
-        residual_variance,
-        return_moments=False,
-        verbose=False,
-        float_type=np.float64
-        ):
+
+
+def compute_lbf(
+    V,
+    Y_list,
+    X_std_list,
+    X_l2_arr,
+    rho,
+    residual_variance,
+    return_moments=False,
+    verbose=False,
+    float_type=np.float64,
+):
 
     num_pops = len(Y_list)
-    
-    
+
     num_variables = X_std_list[0].shape[1]
     lbf = np.zeros(num_variables, dtype=float_type)
-    
+
     if return_moments:
         post_mean = np.zeros((num_pops, num_variables), dtype=float_type)
         post_mean2 = np.zeros((num_pops, num_pops, num_variables), dtype=float_type)
@@ -461,14 +533,14 @@ def compute_lbf(V, Y_list, X_std_list, X_l2_arr,
     elif np.any(np.isclose(V, 0)):
         nonzero_pops = np.flatnonzero(~np.isclose(V, 0))
         lbf_out = compute_lbf(
-            V = V[nonzero_pops], 
-            Y_list = [Y_list[i] for i in nonzero_pops], 
-            X_std_list = [X_std_list[i] for i in nonzero_pops], 
-            X_l2_arr = X_l2_arr[nonzero_pops], 
-            rho = rho[nonzero_pops, :][:, nonzero_pops], 
-            residual_variance = residual_variance[nonzero_pops], 
-            return_moments = return_moments, 
-            float_type = float_type
+            V=V[nonzero_pops],
+            Y_list=[Y_list[i] for i in nonzero_pops],
+            X_std_list=[X_std_list[i] for i in nonzero_pops],
+            X_l2_arr=X_l2_arr[nonzero_pops],
+            rho=rho[nonzero_pops, :][:, nonzero_pops],
+            residual_variance=residual_variance[nonzero_pops],
+            return_moments=return_moments,
+            float_type=float_type,
         )
         if return_moments:
             post_mean = np.zeros((num_pops, num_variables), dtype=float_type)
@@ -480,142 +552,231 @@ def compute_lbf(V, Y_list, X_std_list, X_l2_arr,
             lbf = lbf_out
 
     else:
-        #compute YT_invD_Z = Y.T * inv(D) * Z - i.e., the inner product of Y on all X in each population, scaled by 1/sigma2 for that population
-        YT_invD_Z = np.array([Y.dot(X)/sigma2 for Y,X,sigma2 in zip(Y_list, X_std_list, residual_variance)], dtype=float_type)
-    
-        #compute A (the effects covariance matrix) and its inverse and log-determinant
+        # compute YT_invD_Z = Y.T * inv(D) * Z - i.e., the inner product of Y on all X in each population, scaled by 1/sigma2 for that population
+        YT_invD_Z = np.array(
+            [
+                Y.dot(X) / sigma2
+                for Y, X, sigma2 in zip(Y_list, X_std_list, residual_variance)
+            ],
+            dtype=float_type,
+        )
+
+        # compute A (the effects covariance matrix) and its inverse and log-determinant
         A = rho * np.sqrt(np.outer(V, V))
         inv_A = np.linalg.inv(A)
         logdet_A_sign, logdetA = np.linalg.slogdet(A)
-    
-        for i in range(num_variables):
-        
-            #compute the diagonal of Q = Z.T * inv(D) * Z (this is a diagonal matrix)
-            Q_diag = X_l2_arr[:,i] / residual_variance
 
-            #compute log-determinent for inv(A)+Q
+        for i in range(num_variables):
+
+            # compute the diagonal of Q = Z.T * inv(D) * Z (this is a diagonal matrix)
+            Q_diag = X_l2_arr[:, i] / residual_variance
+
+            # compute log-determinent for inv(A)+Q
             Ainv_plus_Q = inv_A + np.diag(Q_diag)
             logdet_Ainv_plus_Q_sign, logdet_Ainv_plus_Q = np.linalg.slogdet(Ainv_plus_Q)
-            assert logdet_Ainv_plus_Q_sign>0
-        
-            #compute inv_Ainv_plus_Q_times_ZT_invD_Y
-            inv_Ainv_plus_Q_times_ZT_invD_Y = np.linalg.solve(Ainv_plus_Q, YT_invD_Z[:,i])
+            assert logdet_Ainv_plus_Q_sign > 0
 
-            #compute log-BF for this variable
-            lbf_1 = 0.5 * YT_invD_Z[:,i].dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
+            # compute inv_Ainv_plus_Q_times_ZT_invD_Y
+            inv_Ainv_plus_Q_times_ZT_invD_Y = np.linalg.solve(
+                Ainv_plus_Q, YT_invD_Z[:, i]
+            )
+
+            # compute log-BF for this variable
+            lbf_1 = 0.5 * YT_invD_Z[:, i].dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
             lbf_2 = -0.5 * (logdetA + logdet_Ainv_plus_Q)
             lbf[i] = lbf_1 + lbf_2
-        
-            #compute posterior moments for this variable
+
+            # compute posterior moments for this variable
             if return_moments:
-                AQ = A*Q_diag
-                post_mean[:,i] = A.dot(YT_invD_Z[:,i]) - AQ.dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
-                post_covar_i = A - AQ.dot(A) + AQ.dot(np.linalg.solve(Ainv_plus_Q, AQ.T)) # AQ is symmetric...
-                post_mean2[:,:,i] = np.maximum(post_covar_i + np.outer(post_mean[:,i], post_mean[:,i]), 0)
-        
+                AQ = A * Q_diag
+                post_mean[:, i] = A.dot(YT_invD_Z[:, i]) - AQ.dot(
+                    inv_Ainv_plus_Q_times_ZT_invD_Y
+                )
+                post_covar_i = (
+                    A - AQ.dot(A) + AQ.dot(np.linalg.solve(Ainv_plus_Q, AQ.T))
+                )  # AQ is symmetric...
+                post_mean2[:, :, i] = np.maximum(
+                    post_covar_i + np.outer(post_mean[:, i], post_mean[:, i]), 0
+                )
+
     if return_moments:
         return lbf, post_mean, post_mean2
     else:
         return lbf
-        
-def single_effect_regression(Y_list, X_std_list, V, X_l2_arr, w_pop,
-        rho,
-        residual_variance, 
-        prior_weights=None,
-        optimize_V=None,
-        check_null_threshold=0,
-        pop_spec_effect_priors = True,
-        alpha = None,
-        mu2 = None,
-        verbose=False,
-        float_type = np.float64
-        ):
 
-    
-    #optimize V if needed (V is sigma_0^2 in the paper)
-    compute_lbf_params = (Y_list, X_std_list, X_l2_arr, rho, residual_variance, False, verbose, float_type)
-    if optimize_V not in ['EM', None]:
+
+def single_effect_regression(
+    Y_list,
+    X_std_list,
+    V,
+    X_l2_arr,
+    w_pop,
+    rho,
+    residual_variance,
+    prior_weights=None,
+    optimize_V=None,
+    check_null_threshold=0,
+    pop_spec_effect_priors=True,
+    alpha=None,
+    mu2=None,
+    verbose=False,
+    float_type=np.float64,
+):
+
+    # optimize V if needed (V is sigma_0^2 in the paper)
+    compute_lbf_params = (
+        Y_list,
+        X_std_list,
+        X_l2_arr,
+        rho,
+        residual_variance,
+        False,
+        verbose,
+        float_type,
+    )
+    if optimize_V not in ["EM", None]:
         V = susiepy_ss.optimize_prior_variance(
-            optimize_V = optimize_V, prior_weights = prior_weights, num_pops = rho.shape[0], 
-            compute_lbf_params=compute_lbf_params, alpha=alpha, post_mean2=mu2, w_pop=w_pop, 
-            check_null_threshold=check_null_threshold, pop_spec_effect_priors = pop_spec_effect_priors, 
-            float_type = float_type, loglik_function = loglik_f)
-        
-    #compute lbf (log Bayes-factors)
-    lbf, post_mean, post_mean2 = compute_lbf(V, Y_list, X_std_list, X_l2_arr, rho, residual_variance, return_moments=True, verbose=verbose)
-    
-    #compute alpha as defined in Appendix A.2
+            optimize_V=optimize_V,
+            prior_weights=prior_weights,
+            num_pops=rho.shape[0],
+            compute_lbf_params=compute_lbf_params,
+            alpha=alpha,
+            post_mean2=mu2,
+            w_pop=w_pop,
+            check_null_threshold=check_null_threshold,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            float_type=float_type,
+            loglik_function=loglik_f,
+        )
+
+    # compute lbf (log Bayes-factors)
+    lbf, post_mean, post_mean2 = compute_lbf(
+        V,
+        Y_list,
+        X_std_list,
+        X_l2_arr,
+        rho,
+        residual_variance,
+        return_moments=True,
+        verbose=verbose,
+    )
+
+    # compute alpha as defined in Appendix A.2
     maxlbf = np.max(lbf)
     w = np.exp(lbf - maxlbf)
     w_weighted = w * prior_weights
     weighted_sum_w = w_weighted.sum()
     alpha = w_weighted / weighted_sum_w
-    
-    #compute log-likelihood (equation A.5)
+
+    # compute log-likelihood (equation A.5)
     lbf_model = maxlbf + np.log(weighted_sum_w)
-    loglik = lbf_model + np.sum([np.sum(stats.norm(0, np.sqrt(sigma2)).logpdf(Y)) for sigma2,Y in zip(residual_variance, Y_list)])
-        
-    if optimize_V == 'EM':
+    loglik = lbf_model + np.sum(
+        [
+            np.sum(stats.norm(0, np.sqrt(sigma2)).logpdf(Y))
+            for sigma2, Y in zip(residual_variance, Y_list)
+        ]
+    )
+
+    if optimize_V == "EM":
         V = susiepy_ss.optimize_prior_variance(
-            optimize_V = optimize_V, prior_weights = prior_weights, num_pops = rho.shape[0],
-            compute_lbf_params=compute_lbf_params, alpha=alpha, post_mean2=post_mean2, w_pop=w_pop, 
-            check_null_threshold=check_null_threshold, pop_spec_effect_priors = pop_spec_effect_priors,
-            float_type=float_type, loglik_function = loglik_f)
-        
-    res = SER_RESULTS(alpha=alpha, mu=post_mean, mu2=post_mean2, lbf=lbf, lbf_model=lbf_model, V=V, loglik=loglik)
+            optimize_V=optimize_V,
+            prior_weights=prior_weights,
+            num_pops=rho.shape[0],
+            compute_lbf_params=compute_lbf_params,
+            alpha=alpha,
+            post_mean2=post_mean2,
+            w_pop=w_pop,
+            check_null_threshold=check_null_threshold,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            float_type=float_type,
+            loglik_function=loglik_f,
+        )
+
+    res = SER_RESULTS(
+        alpha=alpha,
+        mu=post_mean,
+        mu2=post_mean2,
+        lbf=lbf,
+        lbf_model=lbf_model,
+        V=V,
+        loglik=loglik,
+    )
     return res
 
-def update_each_effect(X_std_list, Y_list, s, X_l2_arr, w_pop,
-        rho,
-        estimate_prior_variance=False, 
-        estimate_prior_method='optim',
-        check_null_threshold=0.0,
-        verbose=False,
-        pop_spec_effect_priors = True,
-        float_type = np.float64
-        ):
 
-        
+def update_each_effect(
+    X_std_list,
+    Y_list,
+    s,
+    X_l2_arr,
+    w_pop,
+    rho,
+    estimate_prior_variance=False,
+    estimate_prior_method="optim",
+    check_null_threshold=0.0,
+    verbose=False,
+    pop_spec_effect_priors=True,
+    float_type=np.float64,
+):
+
     if not estimate_prior_variance:
         estimate_prior_method = None
     L = s.alpha.shape[0]
     num_pop = rho.shape[0]
-    
+
     tqdm_L = tqdm(range(L), disable=not verbose, file=sys.stdout)
     for l in tqdm_L:
-        tqdm_L.set_description('csnp %d/%d'%(l+1, L))
+        tqdm_L.set_description("csnp %d/%d" % (l + 1, L))
         R_list = []
         for k in range(len(X_std_list)):
-            s.Xr_list[k] -= X_std_list[k].dot(s.alpha[l] * s.mu[k,l])
+            s.Xr_list[k] -= X_std_list[k].dot(s.alpha[l] * s.mu[k, l])
             R_list.append(Y_list[k] - s.Xr_list[k])
         res = single_effect_regression(
-            R_list, X_std_list, s.V[:,l], X_l2_arr, w_pop,
-            rho, residual_variance=s.sigma2, prior_weights=s.pi,
-            optimize_V=estimate_prior_method, check_null_threshold=check_null_threshold,
-            pop_spec_effect_priors = pop_spec_effect_priors, verbose=verbose, 
-            alpha = s.alpha[l,:], mu2 = s.mu2[:,:,l,:],
-            float_type = float_type
+            R_list,
+            X_std_list,
+            s.V[:, l],
+            X_l2_arr,
+            w_pop,
+            rho,
+            residual_variance=s.sigma2,
+            prior_weights=s.pi,
+            optimize_V=estimate_prior_method,
+            check_null_threshold=check_null_threshold,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            verbose=verbose,
+            alpha=s.alpha[l, :],
+            mu2=s.mu2[:, :, l, :],
+            float_type=float_type,
         )
-              
-        # Update the variational estimate of the posterior mean.
-        s.mu[:,l,:] = res.mu
-        s.alpha[l,:] = res.alpha
-        s.mu2[:,:,l,:] = res.mu2
-        s.V[:,l] = res.V
-        s.lbf[l] = res.lbf_model
-        s.KL[l] = -res.loglik + SER_posterior_e_loglik(X_std_list, R_list, s.sigma2, res.mu * res.alpha, res.mu2[range(num_pop), range(num_pop)] * res.alpha, X_l2_arr, s.n)
-        for k in range(len(X_std_list)):
-            s.Xr_list[k] += X_std_list[k].dot(s.alpha[l] * s.mu[k,l])
 
-        
+        # Update the variational estimate of the posterior mean.
+        s.mu[:, l, :] = res.mu
+        s.alpha[l, :] = res.alpha
+        s.mu2[:, :, l, :] = res.mu2
+        s.V[:, l] = res.V
+        s.lbf[l] = res.lbf_model
+        s.KL[l] = -res.loglik + SER_posterior_e_loglik(
+            X_std_list,
+            R_list,
+            s.sigma2,
+            res.mu * res.alpha,
+            res.mu2[range(num_pop), range(num_pop)] * res.alpha,
+            X_l2_arr,
+            s.n,
+        )
+        for k in range(len(X_std_list)):
+            s.Xr_list[k] += X_std_list[k].dot(s.alpha[l] * s.mu[k, l])
+
     return s
-        
+
+
 def susie_get_pip(s, prior_tol=1e-9):
-    include_idx = np.any(s.V > prior_tol, axis = 0)
+    include_idx = np.any(s.V > prior_tol, axis=0)
     if not np.any(include_idx):
         return np.zeros(s.alpha.shape[1])
     res = s.alpha[include_idx, :]
-    pips = 1 - np.prod(1-res, axis=0)
+    pips = 1 - np.prod(1 - res, axis=0)
     return pips
-        
+
+
 susie_multi = multisusie

--- a/src/MultiSuSiE/susiepy_ss.py
+++ b/src/MultiSuSiE/susiepy_ss.py
@@ -1,13 +1,10 @@
 import numpy as np
 from tqdm import tqdm
-import scipy.linalg as la
 import sys
 import numba
-import copy
 import random
 import functools
 from scipy.optimize import minimize_scalar
-from scipy.optimize import minimize
 
 
 class S: 
@@ -99,7 +96,7 @@ def multisusie_rss(
         because it doesn't have access to the information that would allow us to 
         approximate the minor allele frequency or minor allele count. 
         It's also kind of weird to standardize the genotypes within each 
-        population beacuse variants that are rare in one population and common 
+        population because variants that are rare in one population and common 
         in other other will be assigned huge effect sizes.
 
     R_list: length K list of PxP numpy arrays representing the LD correlation 
@@ -137,7 +134,7 @@ def multisusie_rss(
         and estimate_prior_method is not set to None.
     prior_weights: numpy P-array of floats representing the prior probability
         of causality for each variant. Give None to use a uniform prior
-    standardize: boolean, whether to adjust summmary statistics to be as if 
+    standardize: boolean, whether to adjust summary statistics to be as if 
         genotypes were standardized to have mean 0 and variance 1
     pop_spec_standardization: boolean, if standardize is True, whether to 
         adjust summary statistics to be as if genotypes were standardized
@@ -157,7 +154,7 @@ def multisusie_rss(
         for a component to be included when estimating PIPs
     max_iter: integer, maximum number of iterations to run
     tol: float, after iter_before_zeroing_effects iterations, results
-        are returned if the ELBO increases by less than tol in an ieration
+        are returned if the ELBO increases by less than tol in an iteration
     verbose: boolean which indicates if an progress bar should be displayed
     coverage: float representing the minimum coverage of credible sets
     min_abs_corr: float representing the minimum absolute correlation between
@@ -177,7 +174,7 @@ def multisusie_rss(
         than this value in a single population will be censored in that population.
         The variant will not be censored in the other populations. 
         If mac_list is not None, mac_list is used for the filtering.
-        If mac_list is None, but maf_list is not, mac is caclulated using
+        If mac_list is None, but maf_list is not, mac is calculated using
         maf_list and population_sizes. Otherwise, if mac_list is None, 
         maf_list is None, and b_list and s_list are provided as input, then
         minor allele counts will be estimated under an assumption of
@@ -185,10 +182,10 @@ def multisusie_rss(
     mac_list: length K list of floats representing the minor allele count for
         each variant in each population.
     multi_population_maf_thresh: float, variants with minor allele frequency 
-        less than this value in ALL poopulations will be censored. Note that 
+        less than this value in ALL populations will be censored. Note that 
         it's probably faster computationally to do this before calling this 
         function. If maf_list is not None, maf_list is used for the filtering.
-        If maf_list is None, but mac_list is not, maf is caclulated using
+        If maf_list is None, but mac_list is not, maf is calculated using
         mac_list and population_sizes. Otherwise, if maf_list is None, 
         mac_list is None, and b_list and s_list are provided as input, then
         minor allele frequencies will be estimated under an assumption of
@@ -266,14 +263,20 @@ def multisusie_rss(
     # check input list lengths
     K = len(R_list)
     if z_list is None:
-        assert len(s_list) == K
-        assert len(b_list) == K
+        if len(s_list) != K:
+            raise ValueError("s_list and R_list must have the same length")
+        if len(b_list) != K:
+            raise ValueError("b_list and R_list must have the same length")
     else:
-        assert len(z_list) == K
+        if len(z_list) != K:
+            raise ValueError("z_list and R_list must have the same length")
     if varY_list is not None:
-        assert len(varY_list) == K
-    assert len(population_sizes) == K
-    assert np.isscalar(rho) | ((rho.shape[0] == K) & (rho.shape[1] == K))
+        if len(varY_list) != K:
+            raise ValueError("varY_list and R_list must have the same length")
+    if len(population_sizes) != K:
+        raise ValueError("population_sizes and R_list must have the same length")
+    if not (np.isscalar(rho) or ((rho.shape[0] == K) and (rho.shape[1] == K))):
+        raise ValueError("rho must be a scalar or a K x K matrix where K=len(R_list)")
 
     # make copies of R if low_memory_mode=False to avoid modifying the input data 
     if low_memory_mode:
@@ -438,7 +441,7 @@ susie_multi_rss = multisusie_rss
 def recover_XTX_and_XTY(b, s, R, YTY, n):
     """ Recover XTX and XTY from GWAS summary statistics. INPUT R IS MUTATED 
 
-    THIS FUNCTION MUTATES INPUT R to reduce memory consumpation. BE CAREFUL!! 
+    THIS FUNCTION MUTATES INPUT R to reduce memory consumption. BE CAREFUL!! 
     see page 4 of the supplement of Zou et al. 2022 PLoS Genetics for a derivation
 
     Parameters
@@ -470,7 +473,7 @@ def recover_XTX_and_XTY(b, s, R, YTY, n):
 def recover_XTX_and_XTY_from_Z(z, R, n, float_type = np.float32):
     """ Recover XTX and XTY from z scores and LD correlation matrix
 
-    THIS FUNCTION MUTATES INPUT R to reduce memory consumpation. BE CAREFUL!! 
+    THIS FUNCTION MUTATES INPUT R to reduce memory consumption. BE CAREFUL!! 
     This is equivalent to using standardized genotype and phenotype
 
     Parameters
@@ -541,7 +544,7 @@ def susie_multi_ss(
         and estimate_prior_method is not set to None.
     prior_weights: numpy P-array of floats representing the prior probability
         of causality for each variant. Give None to use a uniform prior
-    standardize: boolean, whether to adjust summmary statistics to be as if 
+    standardize: boolean, whether to adjust summary statistics to be as if 
         genotypes were standardized to have mean 0 and variance 1
     pop_spec_standardization: boolean, if standardize is True, whether to 
         adjust summary statistics to be as if genotypes were standardized
@@ -562,7 +565,7 @@ def susie_multi_ss(
         for a component to be included when estimating PIPs
     max_iter: integer, maximum number of iterations to run
     tol: float, after iter_before_zeroing_effects iterations, results
-        are returned if the ELBO increases by less than tol in an ieration
+        are returned if the ELBO increases by less than tol in an iteration
     verbose: boolean which indicates if an progress bar should be displayed
     R_list: length K list of PxP numpy arrays representing the LD correlation.
         If set to None, and min_abs_corr > 0, the LD correlation matrices will
@@ -606,13 +609,17 @@ def susie_multi_ss(
     """
 
     #check input dimensions
-    assert len(XTX_list) == len(XTY_list)
-    assert np.all([XTX.shape[1] == XTX_list[0].shape[1] for XTX in XTX_list])
-    assert np.all([XTX.shape[0] == XTY.shape[0] for (XTX,XTY) in zip(XTX_list, XTY_list)])
+    if len(XTX_list) != len(XTY_list):
+        raise ValueError("XTX_list and XTY_list must have the same length")
+    if not np.all([XTX.shape[1] == XTX_list[0].shape[1] for XTX in XTX_list]):
+        raise ValueError("all matrices in XTX_list must have the same number of columns")
+    if not np.all([XTX.shape[0] == XTY.shape[0] for (XTX, XTY) in zip(XTX_list, XTY_list)]):
+        raise ValueError("each XTX_list[i] and XTY_list[i] must have matching dimensions")
     if prior_weights is not None:
         prior_weights = prior_weights.astype(float_type)
 
-    assert not np.any([np.any(np.isnan(XTX)) for XTX in XTX_list])
+    if np.any([np.any(np.isnan(XTX)) for XTX in XTX_list]):
+        raise ValueError("XTX_list must not contain NaN values")
         
     #compute w_pop (the relative size of each population)
     population_sizes = np.array(population_sizes)
@@ -621,7 +628,8 @@ def susie_multi_ss(
     #compute rho properties
     rho = rho.astype(float_type)
     logdet_rho_sign, logdet_rho = np.linalg.slogdet(rho)
-    assert logdet_rho_sign>0
+    if logdet_rho_sign <= 0:
+        raise ValueError("rho must be positive definite")
 
     X_l2_arr = np.array([np.diag(XTX) for XTX in XTX_list], dtype = float_type)
 
@@ -645,13 +653,14 @@ def susie_multi_ss(
     #init setup
     p = XTX_list[0].shape[1]
 
-    if np.isscalar(scaled_prior_variance) & standardize:
-        assert 0 < scaled_prior_variance <= 1
+    if np.isscalar(scaled_prior_variance) and standardize and not (0 < scaled_prior_variance <= 1):
+        raise ValueError("scaled_prior_variance must be in (0, 1] when scalar and standardize=True")
     if prior_weights is None:
         prior_weights = np.zeros(p, dtype=float_type) + 1.0/p
     else:
         prior_weights = (prior_weights / np.sum(prior_weights)).astype(float_type)
-    assert prior_weights.shape[0] == p
+    if prior_weights.shape[0] != p:
+        raise ValueError("prior_weights must have length equal to the number of variants")
     if p<L: L=p
 
     # initialize s, which tracks the current model parameter estimates
@@ -716,7 +725,7 @@ def susie_multi_ss(
                 float_type = float_type
             )
             if np.any(s.sigma2 < 0):
-                print('minimum resdiual variance less than 0. Is there mismatch between the correlation matrix and association statistics?')
+                print('minimum residual variance less than 0. Is there mismatch between the correlation matrix and association statistics?')
 
     elbo = elbo[1:i+2] # Remove first (infinite) entry, and trailing NAs.
     s.elbo = elbo
@@ -1283,4 +1292,3 @@ def recover_R_from_XTX(XTX, X_l2):
     with np.errstate(divide='ignore', invalid = 'ignore'):
         XTX /= np.sqrt(np.nan_to_num(X_l2, 1))
         XTX /= np.sqrt(np.expand_dims(np.nan_to_num(X_l2, 1), 1))
-

--- a/src/MultiSuSiE/susiepy_ss.py
+++ b/src/MultiSuSiE/susiepy_ss.py
@@ -7,15 +7,23 @@ import functools
 from scipy.optimize import minimize_scalar
 
 
-class S: 
+class S:
     def __init__(
-            self, pop_sizes, L, XTX_list, scaled_prior_variance, 
-            residual_variance, varY, prior_weights, float_type = np.float32):
-        
-        #code from init_setup
+        self,
+        pop_sizes,
+        L,
+        XTX_list,
+        scaled_prior_variance,
+        residual_variance,
+        varY,
+        prior_weights,
+        float_type=np.float32,
+    ):
+
+        # code from init_setup
         num_pop = len(pop_sizes)
         p = XTX_list[0].shape[0]
-        self.alpha = np.zeros((L, p), dtype=float_type) + 1.0/p
+        self.alpha = np.zeros((L, p), dtype=float_type) + 1.0 / p
         self.mu = np.zeros((num_pop, L, p), dtype=float_type)
         self.mu2 = np.zeros((num_pop, num_pop, L, p), dtype=float_type)
         self.Xr_list = [np.zeros(XTX.shape[0], dtype=float_type) for XTX in XTX_list]
@@ -23,16 +31,17 @@ class S:
         self.pi = prior_weights.astype(float_type)
         self.n = np.array(pop_sizes)
         self.L = L
-        
-        #code from init_finalize
+
+        # code from init_finalize
         self.V = scaled_prior_variance * varY + np.zeros((num_pop, L), dtype=float_type)
         self.V = self.V.astype(float_type)
         assert np.all(self.V >= 0)
         self.ER2 = np.zeros(num_pop, dtype=float_type) + np.nan
         self.KL = np.zeros(L, dtype=float_type) + np.nan
         self.lbf = np.zeros(L, dtype=float_type) + np.nan
-        
+
         self.converged = False
+
 
 class SER_RESULTS:
     def __init__(self, alpha, mu, mu2, lbf, lbf_model, V):
@@ -43,40 +52,40 @@ class SER_RESULTS:
         self.V = V
         self.lbf_model = lbf_model
 
+
 def multisusie_rss(
-    R_list,
-    population_sizes,
-    b_list = None,
-    s_list = None,
-    z_list = None,
-    varY_list = None,
-    rho = 0.75,
-    L = 10,
-    scaled_prior_variance = 0.2,
-    prior_weights = None,
-    standardize = False, 
-    pop_spec_standardization = True,
-    estimate_residual_variance = True,
-    estimate_prior_variance = True,
-    estimate_prior_method = 'early_EM',
-    pop_spec_effect_priors = True,
-    iter_before_zeroing_effects = 5,
-    prior_tol = 1e-9,
-    max_iter = 100,
-    tol = 1e-3,
-    verbose = False,
-    coverage = 0.95,
-    min_abs_corr = 0,
-    float_type = np.float32,
-    low_memory_mode = False,
-    recover_R = False,
-    single_population_mac_thresh = 20,
-    mac_list = None,
-    multi_population_maf_thresh = 0,
-    maf_list = None,
-    variant_ids = None
-    ):
-    """ Top-level function for running MultiSuSiE with summary statistics
+    R_list: list[np.ndarray],
+    population_sizes: list[int | float],
+    b_list: list[np.ndarray] | None = None,
+    s_list: list[np.ndarray] | None = None,
+    z_list: list[np.ndarray] | None = None,
+    varY_list: list[float] | None = None,
+    rho: float | np.ndarray = 0.75,
+    L: int = 10,
+    scaled_prior_variance: float | np.ndarray = 0.2,
+    prior_weights: np.ndarray | None = None,
+    standardize: bool = False,
+    pop_spec_standardization: bool = True,
+    estimate_residual_variance: bool = True,
+    estimate_prior_variance: bool = True,
+    estimate_prior_method: str | None = "early_EM",
+    pop_spec_effect_priors: bool = True,
+    iter_before_zeroing_effects: int = 5,
+    prior_tol: float = 1e-9,
+    max_iter: int = 100,
+    tol: float = 1e-3,
+    verbose: bool = False,
+    coverage: float = 0.95,
+    min_abs_corr: float = 0,
+    float_type: type = np.float32,
+    low_memory_mode: bool = False,
+    single_population_mac_thresh: float = 20,
+    mac_list: list[np.ndarray] | None = None,
+    multi_population_maf_thresh: float = 0,
+    maf_list: list[np.ndarray] | None = None,
+    variant_ids: list[str] | None = None,
+) -> S:
+    """Top-level function for running MultiSuSiE with summary statistics
 
     This function takes takes standard GWAS summary statistics, converts
     them to sufficient statistics, and runs MultiSuSiE on them.
@@ -87,19 +96,19 @@ def multisusie_rss(
     1. b_list, s_list, R_list, varY_list, rho, population_sizes
         This is the preferred input format and is used in the MultiSuSiE paper.
     2. z_list, R_list, rho, population_sizes
-        Here, we assume that both the genotypes and phenotypes have been 
-        standardized to have variance 1 within each population.  It's extremely 
-        important to censor low MAF variants in the population where they are rare. 
-        This is done by setting values in z_list for these variants to 0, and 
+        Here, we assume that both the genotypes and phenotypes have been
+        standardized to have variance 1 within each population.  It's extremely
+        important to censor low MAF variants in the population where they are rare.
+        This is done by setting values in z_list for these variants to 0, and
         columns and rows corresponding to these variants to 0. multisusie_rss
-        will not do this for you (but will with the first input combination) 
-        because it doesn't have access to the information that would allow us to 
-        approximate the minor allele frequency or minor allele count. 
-        It's also kind of weird to standardize the genotypes within each 
-        population because variants that are rare in one population and common 
+        will not do this for you (but will with the first input combination)
+        because it doesn't have access to the information that would allow us to
+        approximate the minor allele frequency or minor allele count.
+        It's also kind of weird to standardize the genotypes within each
+        population because variants that are rare in one population and common
         in other other will be assigned huge effect sizes.
 
-    R_list: length K list of PxP numpy arrays representing the LD correlation 
+    R_list: length K list of PxP numpy arrays representing the LD correlation
         matrices for each population. Each array should correspond
         to the same set of P variants, in the same order. Variants that should
         not be included in a given population due to low MAF can be assigned a
@@ -111,7 +120,7 @@ def multisusie_rss(
         to the same set of P variants, in the same order. Variants that should
         not be included in a given population due to low MAF can be assigned a
         value of np.nan. Provide exactly one of (b_list and s_list) and z_list.
-    s_list: length K list of length P numpy arrays containing effect size 
+    s_list: length K list of length P numpy arrays containing effect size
         standard errors, one for each population. Each array should correspond
         to the same set of P variants, in the same order. Variants that should
         not be included in a given population due to low MAF can be assigned a
@@ -123,20 +132,21 @@ def multisusie_rss(
         Provide exactly one of (b_list and s_list) and z_list.
     varY_list: length K list representing the sample variance of the outcome
         in each population
-    rho: PxP numpy array representing the effect size correlation matrix. In 
+    rho: scalar or KxK numpy array representing the cross-population effect
+        size correlation matrix. In
         the manuscript, we show that this parameter has little impact on the
         estimated PIPs in practice.
     L: integer representing the maximum number of causal variants
     scaled_prior_variance: float representing the effect size prior variance,
-        scaled by the residual variance. It's fine to set this to a number 
-        larger than what you expect the squared effect size to be (like the 
+        scaled by the residual variance. It's fine to set this to a number
+        larger than what you expect the squared effect size to be (like the
         default value of 0.2) as long as estimate_prior_variance is set to True
         and estimate_prior_method is not set to None.
     prior_weights: numpy P-array of floats representing the prior probability
         of causality for each variant. Give None to use a uniform prior
-    standardize: boolean, whether to adjust summary statistics to be as if 
+    standardize: boolean, whether to adjust summary statistics to be as if
         genotypes were standardized to have mean 0 and variance 1
-    pop_spec_standardization: boolean, if standardize is True, whether to 
+    pop_spec_standardization: boolean, if standardize is True, whether to
         adjust summary statistics to be as if genotypes were standardized
         separately for each population, or pooled and then standardized
     estimate_residual_variance: boolean, whether to estimate the residual variance, $\\sigma^2_k$ in the manuscript
@@ -144,11 +154,11 @@ def multisusie_rss(
         $A^{(l)}$ in the manuscript
     estimate_prior_method: string, method to estimate the prior variance. Recommended
         values are 'early_EM' or None
-    pop_spec_effect_priors: boolean, whether to estimate separate prior 
+    pop_spec_effect_priors: boolean, whether to estimate separate prior
         variance parameters for each population
     iter_before_zeroing_effects: integer, number of iterations to run before
-        zeroing out component-population pairs (or components if 
-        pop_spec_effect_priors is False) that have a lower likelihood than a 
+        zeroing out component-population pairs (or components if
+        pop_spec_effect_priors is False) that have a lower likelihood than a
         null model
     prior_tol: float which places a filter on the minimum prior variance
         for a component to be included when estimating PIPs
@@ -159,68 +169,67 @@ def multisusie_rss(
     coverage: float representing the minimum coverage of credible sets
     min_abs_corr: float representing the minimum absolute correlation between
         any pair of variants in a credible set (purity). For each pair of variants,
-        the max is taken across ancestries. In the case where min_abs_corr = 0,
-        low_memory_mode = True, and recover_R = False, the purity of credible
-        sets will not be calculated. 
+        the max is taken across ancestries. In the case where min_abs_corr = 0
+        and low_memory_mode = True, the purity of credible sets will not be
+        calculated.
     float_type: numpy float type used. Set to np.float32 to minimize memory
         consumption
-    low_memory_mode: boolean, if True, the input R_list will be modified in place.
-        Decreases memory consumption by a factor of two. BUT, THE INPUT R_list
-        WILL BE OVERWRITTEN. If you need R_list, set low_memory_mode to False
-    recover_R: boolean, if True, the R matrices will be recovered from XTX, 
-        BUT variants with MAC/MAF estimate less than mac_filter/maf_filter will
-        be censored. 
+    low_memory_mode: boolean. If True, the input R_list may be modified in
+        place to reduce memory consumption. This can change the provided numpy
+        arrays after multisusie_rss is complete. If you need R_list unchanged
+        after this call, set
+        low_memory_mode to False.
     single_population_mac_thresh: float, variants with minor allele count less
         than this value in a single population will be censored in that population.
-        The variant will not be censored in the other populations. 
+        The variant will not be censored in the other populations.
         If mac_list is not None, mac_list is used for the filtering.
         If mac_list is None, but maf_list is not, mac is calculated using
-        maf_list and population_sizes. Otherwise, if mac_list is None, 
+        maf_list and population_sizes. Otherwise, if mac_list is None,
         maf_list is None, and b_list and s_list are provided as input, then
         minor allele counts will be estimated under an assumption of
-        Hardy-Weinberg equilibrium. 
+        Hardy-Weinberg equilibrium.
     mac_list: length K list of floats representing the minor allele count for
         each variant in each population.
-    multi_population_maf_thresh: float, variants with minor allele frequency 
-        less than this value in ALL populations will be censored. Note that 
-        it's probably faster computationally to do this before calling this 
+    multi_population_maf_thresh: float, variants with minor allele frequency
+        less than this value in ALL populations will be censored. Note that
+        it's probably faster computationally to do this before calling this
         function. If maf_list is not None, maf_list is used for the filtering.
         If maf_list is None, but mac_list is not, maf is calculated using
-        mac_list and population_sizes. Otherwise, if maf_list is None, 
+        mac_list and population_sizes. Otherwise, if maf_list is None,
         mac_list is None, and b_list and s_list are provided as input, then
         minor allele frequencies will be estimated under an assumption of
-        Hardy-Weinberg equilibrium. 
+        Hardy-Weinberg equilibrium.
     maf_list: length K list of floats representing the minor allele frequency for
-        each variant in each population. 
-    variant_ids: length P list of strings representing the variant IDs. If 
+        each variant in each population.
+    variant_ids: length P list of strings representing the variant IDs. If
         provided, sets will contain a fifth entry, containing the variant ids
-        of the variants contained in each set. 
-    
+        of the variants contained in each set.
+
     Returns
     -------
     an object containing results with the following attributes:
         pip: length-P numpy array of posterior inclusion probabilities
-        coef: K x P numpy array of posterior effect size estimates for 
+        coef: K x P numpy array of posterior effect size estimates for
             each variant in each population, aggregated across
-            all L single effect regressions. These effects are not 
+            all L single effect regressions. These effects are not
             conditional on each variant being a causal variant and thus
             account for uncertainty in the causal variant assignment.
         coef_sd: K x P numpy array of posterior effect size standard deviations
             for each variant in each population, aggregated across
             all L single effect regressions.
-        sets: a list with four entries. The first contains the indices of the 
+        sets: a list with four entries. The first contains the indices of the
             variants contained in each set. The second contains the purity
-            of each set (see min_abs_corr for calculation details). The 
+            of each set (see min_abs_corr for calculation details). The
             third contains the coverage of each set. The fourth contains
-            whether the set has passed filtering. If variant_ids is 
-            provided, a fifth entry contains the variant ids for the 
-            variants contained in each set. 
-        alpha: L x P numpy array of single-effect regression posterior 
+            whether the set has passed filtering. If variant_ids is
+            provided, a fifth entry contains the variant ids for the
+            variants contained in each set.
+        alpha: L x P numpy array of single-effect regression posterior
             inclusion probabilities
         mu: K x L x P numpy array of single-effect regression effect size
             posterior means, conditional on each variant being the causal variant
         mu2: K x K x L x P numpy array of single-effect regression effect size
-            posterior seconds moments, conditional on each variant being the 
+            posterior seconds moments, conditional on each variant being the
             causal variant
         sigma2: length-K numpy array of residual variance estimates
         pi: length-P numpy array of prior inclusion probabilities
@@ -230,13 +239,13 @@ def multisusie_rss(
         ER2: length-K numpy array of expected squared residuals
         KL: L x 1 numpy array of Kullback-Leibler divergences for each single
             effect regression
-        lbf: L x 1 numpy array of log Bayes factors for each single effect 
+        lbf: L x 1 numpy array of log Bayes factors for each single effect
             regression
         converged: boolean indicating whether the algorithm converged
         niter: integer representing the number of IBSS iterations required
             to reach convergence
 
-            
+
 
     TODO
     ----
@@ -247,18 +256,20 @@ def multisusie_rss(
         - Implement missing functionality for individual-level multisusie
     """
 
-    
     # provide exactly one of (b_list and s_list) and z_list
     if (z_list is not None) & ((b_list is not None) or (s_list is not None)):
-        raise ValueError('provide either (b_list and s_list) or z_list, but not both. ' + \
-                         'See the parameters section of help(multisusie_rss) for more information')
+        raise ValueError(
+            "provide either (b_list and s_list) or z_list, but not both. "
+            + "See the parameters section of help(multisusie_rss) for more information"
+        )
     if (z_list is None) & (b_list is None) & (s_list is None):
-        raise ValueError('provide either (b_list and s_list) or z_list, but not both')
+        raise ValueError("provide either (b_list and s_list) or z_list, but not both")
     if (b_list is not None) & ((s_list is None) | (varY_list is None)):
-        raise ValueError('if b_list is provided, s_list and varY_list must also be provided')
+        raise ValueError(
+            "if b_list is provided, s_list and varY_list must also be provided"
+        )
     if population_sizes is None:
-        raise ValueError('population_sizes must be provided')
-
+        raise ValueError("population_sizes must be provided")
 
     # check input list lengths
     K = len(R_list)
@@ -278,7 +289,7 @@ def multisusie_rss(
     if not (np.isscalar(rho) or ((rho.shape[0] == K) and (rho.shape[1] == K))):
         raise ValueError("rho must be a scalar or a K x K matrix where K=len(R_list)")
 
-    # make copies of R if low_memory_mode=False to avoid modifying the input data 
+    # make copies of R if low_memory_mode=False to avoid modifying the input data
     if low_memory_mode:
         R_list_copy = R_list
         if z_list is None:
@@ -286,11 +297,13 @@ def multisusie_rss(
             s_list_copy = s_list
         else:
             z_list_copy = z_list
-        print('low memory mode is on. THE INPUT R MATRICES HAVE BEEN ' +
-            'TRANSFORMED INTO XTX AND CENSORED BASED ON MISSINGNESS. ' +
-            'THE INPUT R MATRICES HAVE BEEN CHANGED. The datatypes of ' +
-            'b_list, s_list, and R_list have been mutated in place ' +
-            'to match float_type')
+        print(
+            "low memory mode is on. THE INPUT R MATRICES HAVE BEEN "
+            + "TRANSFORMED INTO XTX AND CENSORED BASED ON MISSINGNESS. "
+            + "THE INPUT R MATRICES HAVE BEEN CHANGED. The datatypes of "
+            + "b_list, s_list, and R_list have been mutated in place "
+            + "to match float_type"
+        )
     else:
         R_list_copy = [np.copy(R) for R in R_list]
         if z_list is None:
@@ -303,27 +316,26 @@ def multisusie_rss(
     for i in range(K):
         if z_list is None:
             if b_list_copy[i].dtype != float_type:
-                b_list_copy[i] = b_list_copy[i].astype(float_type, copy = False)
+                b_list_copy[i] = b_list_copy[i].astype(float_type, copy=False)
             if s_list_copy[i].dtype != float_type:
-                s_list_copy[i] = s_list_copy[i].astype(float_type, copy = False)
+                s_list_copy[i] = s_list_copy[i].astype(float_type, copy=False)
         else:
             if z_list_copy[i].dtype != float_type:
-                z_list_copy[i] = z_list_copy[i].astype(float_type, copy = False)
+                z_list_copy[i] = z_list_copy[i].astype(float_type, copy=False)
         if R_list_copy[i].dtype != float_type:
-            R_list_copy[i] = R_list_copy[i].astype(float_type, copy = False)
+            R_list_copy[i] = R_list_copy[i].astype(float_type, copy=False)
         if (not np.isscalar(rho)) and (rho.dtype != float_type):
-            rho = rho.astype(float_type, copy = True)
+            rho = rho.astype(float_type, copy=True)
 
-    population_sizes = np.array(population_sizes, dtype = float_type)
+    population_sizes = np.array(population_sizes, dtype=float_type)
     if varY_list is None:
-        varY_list = np.ones(K, dtype = float_type)
+        varY_list = np.ones(K, dtype=float_type)
     else:
-        varY_list = np.array(varY_list, dtype = float_type)
+        varY_list = np.array(varY_list, dtype=float_type)
     YTY_list = []
     for i in range(K):
         YTY = (varY_list[i] * (population_sizes[i] - 1)).astype(float_type)
         YTY_list.append(YTY)
-
 
     # convert GWAS summary statistics to MultiSuSiE sufficient statistics
     XTX_list = []
@@ -332,11 +344,11 @@ def multisusie_rss(
         for i in range(K):
             # this function mutates R_list_copy[i]
             XTY = recover_XTX_and_XTY(
-                b = b_list_copy[i],
-                s = s_list_copy[i],
-                R = R_list_copy[i],
-                YTY = YTY_list[i],
-                n = population_sizes[i]
+                b=b_list_copy[i],
+                s=s_list_copy[i],
+                R=R_list_copy[i],
+                YTY=YTY_list[i],
+                n=population_sizes[i],
             )
             XTY_list.append(XTY)
         XTX_list = R_list_copy
@@ -344,10 +356,10 @@ def multisusie_rss(
         for i in range(K):
             # this function mutates R_list_copy[i]
             XTX, XTY = recover_XTX_and_XTY_from_Z(
-                z = z_list_copy[i],
-                R = R_list_copy[i],
-                n = population_sizes[i],
-                float_type = float_type
+                z=z_list_copy[i],
+                R=R_list_copy[i],
+                n=population_sizes[i],
+                float_type=float_type,
             )
             XTX_list.append(XTX)
             XTY_list.append(XTY)
@@ -361,19 +373,25 @@ def multisusie_rss(
             elif maf_list is not None:
                 mac = np.minimum(2 * n * maf_list[i], 2 * n - 2 * n * maf_list[i])
             elif b_list is not None:
-                var_x = np.minimum(np.diag(XTX_list[i]) / (n - 1), .5) # this can be > .5 due to HWE violations?
+                var_x = np.minimum(
+                    np.diag(XTX_list[i]) / (n - 1), 0.5
+                )  # this can be > .5 due to HWE violations?
                 maf = 1 / 2 - np.sqrt(1 - 2 * var_x) / 2
                 mac = np.minimum(2 * n * maf, 2 * n - 2 * n * maf)
             else:
-                print(f'Skipping MAC filtering because mac_list is not provided,' +
-                      'maf_list is not provided, and z-scores are being used')
+                print(
+                    f"Skipping MAC filtering because mac_list is not provided,"
+                    + "maf_list is not provided, and z-scores are being used"
+                )
                 continue
             low_mac_mask = mac < single_population_mac_thresh
             XTX_list[i][low_mac_mask, :] = 0
             XTX_list[i][:, low_mac_mask] = 0
             XTY_list[i][low_mac_mask] = 0
-            print(f'Censored {np.sum(low_mac_mask)} variants in population {i}' +
-                  ' due to low population-specific MAC')
+            print(
+                f"Censored {np.sum(low_mac_mask)} variants in population {i}"
+                + " due to low population-specific MAC"
+            )
 
     # do minor allele frequency filtering across populations. this filter
     # only censors a variant if it has low MAF in all populations
@@ -386,62 +404,67 @@ def multisusie_rss(
             elif mac_list is not None:
                 maf = np.minimum(mac_list[i] / (2 * n), 1 - mac_list[i] / (2 * n))
             elif b_list is not None:
-                var_x = np.minimum(np.diag(XTX_list[i]) / (n - 1), .5)
+                var_x = np.minimum(np.diag(XTX_list[i]) / (n - 1), 0.5)
                 maf = 1 / 2 - np.sqrt(1 - 2 * var_x) / 2
             else:
-                print(f'Skipping MAF filtering because mac_list is not provided,' +
-                      'maf_list is not provided, and z-scores are being used')
-            low_maf_across_populations_mask = low_maf_across_populations_mask & (maf < multi_population_maf_thresh)
-        print(f'Censored {np.sum(low_maf_across_populations_mask)} variants in' +
-            ' all populations due to low MAF across all populations')
+                print(
+                    f"Skipping MAF filtering because mac_list is not provided,"
+                    + "maf_list is not provided, and z-scores are being used"
+                )
+            low_maf_across_populations_mask = low_maf_across_populations_mask & (
+                maf < multi_population_maf_thresh
+            )
+        print(
+            f"Censored {np.sum(low_maf_across_populations_mask)} variants in"
+            + " all populations due to low MAF across all populations"
+        )
         for i in range(K):
             XTX_list[i][low_maf_across_populations_mask, :] = 0
             XTX_list[i][:, low_maf_across_populations_mask] = 0
             XTY_list[i][low_maf_across_populations_mask] = 0
 
-
-
     if np.isscalar(rho):
         rho = np.ones((K, K), dtype=float_type) * rho
         rho[np.diag_indices(K)] = 1
-    
+
     s = susie_multi_ss(
-        XTX_list = XTX_list,
-        XTY_list = XTY_list, 
-        YTY_list = YTY_list, 
-        rho = rho, 
-        population_sizes = population_sizes,
-        L = L, 
-        scaled_prior_variance = scaled_prior_variance,
-        prior_weights = prior_weights,
-        standardize = standardize,
-        pop_spec_standardization = pop_spec_standardization,
-        estimate_residual_variance = estimate_residual_variance,
-        estimate_prior_variance = estimate_prior_variance,
-        estimate_prior_method = estimate_prior_method,
-        prior_tol = prior_tol,
-        max_iter = max_iter,
-        tol = tol,
-        verbose = verbose,
-        iter_before_zeroing_effects = iter_before_zeroing_effects,
-        pop_spec_effect_priors = pop_spec_effect_priors,
-        R_list = R_list,
-        coverage = coverage,
-        min_abs_corr = min_abs_corr,
-        float_type = float_type,
-        low_memory_mode = low_memory_mode,
-        recover_R = recover_R,
-        variant_ids = variant_ids
+        XTX_list=XTX_list,
+        XTY_list=XTY_list,
+        YTY_list=YTY_list,
+        rho=rho,
+        population_sizes=population_sizes,
+        L=L,
+        scaled_prior_variance=scaled_prior_variance,
+        prior_weights=prior_weights,
+        standardize=standardize,
+        pop_spec_standardization=pop_spec_standardization,
+        estimate_residual_variance=estimate_residual_variance,
+        estimate_prior_variance=estimate_prior_variance,
+        estimate_prior_method=estimate_prior_method,
+        prior_tol=prior_tol,
+        max_iter=max_iter,
+        tol=tol,
+        verbose=verbose,
+        iter_before_zeroing_effects=iter_before_zeroing_effects,
+        pop_spec_effect_priors=pop_spec_effect_priors,
+        R_list=R_list,
+        coverage=coverage,
+        min_abs_corr=min_abs_corr,
+        float_type=float_type,
+        low_memory_mode=low_memory_mode,
+        variant_ids=variant_ids,
     )
 
     return s
 
+
 susie_multi_rss = multisusie_rss
 
-def recover_XTX_and_XTY(b, s, R, YTY, n):
-    """ Recover XTX and XTY from GWAS summary statistics. INPUT R IS MUTATED 
 
-    THIS FUNCTION MUTATES INPUT R to reduce memory consumption. BE CAREFUL!! 
+def recover_XTX_and_XTY(b, s, R, YTY, n):
+    """Recover XTX and XTY from GWAS summary statistics. INPUT R IS MUTATED
+
+    THIS FUNCTION MUTATES INPUT R to reduce memory consumption. BE CAREFUL!!
     see page 4 of the supplement of Zou et al. 2022 PLoS Genetics for a derivation
 
     Parameters
@@ -462,18 +485,19 @@ def recover_XTX_and_XTY(b, s, R, YTY, n):
 
     #  see page 4 of the supplement of Zou et al. 2022 PLoS Genetics for a derivation
     sigma2 = YTY / ((b / s) ** 2 + n - 2)
-    XTY = np.nan_to_num(sigma2 * b / (s ** 2))
-    dR = np.nan_to_num(sigma2 / (s ** 2))
-    R *= np.expand_dims(np.sqrt(dR), axis = 1)
-    R *=  np.sqrt(dR)
-    np.nan_to_num(R, copy = False)
+    XTY = np.nan_to_num(sigma2 * b / (s**2))
+    dR = np.nan_to_num(sigma2 / (s**2))
+    R *= np.expand_dims(np.sqrt(dR), axis=1)
+    R *= np.sqrt(dR)
+    np.nan_to_num(R, copy=False)
 
     return XTY
 
-def recover_XTX_and_XTY_from_Z(z, R, n, float_type = np.float32):
-    """ Recover XTX and XTY from z scores and LD correlation matrix
 
-    THIS FUNCTION MUTATES INPUT R to reduce memory consumption. BE CAREFUL!! 
+def recover_XTX_and_XTY_from_Z(z, R, n, float_type=np.float32):
+    """Recover XTX and XTY from z scores and LD correlation matrix
+
+    THIS FUNCTION MUTATES INPUT R to reduce memory consumption. BE CAREFUL!!
     This is equivalent to using standardized genotype and phenotype
 
     Parameters
@@ -487,44 +511,46 @@ def recover_XTX_and_XTY_from_Z(z, R, n, float_type = np.float32):
     XTX: PxP numpy array representing the X^T X matrix
     XTY: length-P numpy array representing the X^T Y vector
     """
-    adj = (n - 1) / (z ** 2 + n - 2)
+    adj = (n - 1) / (z**2 + n - 2)
     z = np.sqrt(adj) * z
-    R *= (n - 1)
+    R *= n - 1
     XTY = (np.sqrt(n - 1) * z).astype(float_type)
-    np.nan_to_num(XTY, copy = False)
-    np.nan_to_num(R, copy = False)
+    np.nan_to_num(XTY, copy=False)
+    np.nan_to_num(R, copy=False)
 
     return R, XTY
 
-def susie_multi_ss(
-    XTX_list, XTY_list, YTY_list,
-    rho,
-    population_sizes,
-    L = 10,
-    scaled_prior_variance=0.2,
-    prior_weights=None,
-    standardize = True,
-    pop_spec_standardization = False,
-    estimate_residual_variance=True,
-    estimate_prior_variance=True,
-    estimate_prior_method='early_EM',
-    pop_spec_effect_priors = True,
-    iter_before_zeroing_effects = 5,
-    prior_tol=1e-9,
-    max_iter=100,
-    tol=1e-3,
-    verbose=False,
-    R_list = None,
-    coverage = .95,
-    min_abs_corr = .5,
-    float_type = np.float32,
-    low_memory_mode = False,
-    recover_R = False,
-    variant_ids = None
-    ):
-    """ Run MultiSuSiE on sufficient statistics
 
-    This function runs MultiSuSiE on sufficient statistics. It is designed to 
+def susie_multi_ss(
+    XTX_list: list[np.ndarray],
+    XTY_list: list[np.ndarray],
+    YTY_list: list[float],
+    rho: np.ndarray,
+    population_sizes: list[int | float],
+    L: int = 10,
+    scaled_prior_variance: float | np.ndarray = 0.2,
+    prior_weights: np.ndarray | None = None,
+    standardize: bool = True,
+    pop_spec_standardization: bool = False,
+    estimate_residual_variance: bool = True,
+    estimate_prior_variance: bool = True,
+    estimate_prior_method: str | None = "early_EM",
+    pop_spec_effect_priors: bool = True,
+    iter_before_zeroing_effects: int = 5,
+    prior_tol: float = 1e-9,
+    max_iter: int = 100,
+    tol: float = 1e-3,
+    verbose: bool = False,
+    R_list: list[np.ndarray] | None = None,
+    coverage: float = 0.95,
+    min_abs_corr: float = 0.5,
+    float_type: type = np.float32,
+    low_memory_mode: bool = False,
+    variant_ids: list[str] | None = None,
+) -> S:
+    """Run MultiSuSiE on sufficient statistics
+
+    This function runs MultiSuSiE on sufficient statistics. It is designed to
     be run from the top-level function multisusie_rss, but can be run directly.
     It will not censor based on MAF/MAC, unlike multisusie_rss.
 
@@ -532,21 +558,22 @@ def susie_multi_ss(
     ----------
     XTX_list: length K list of PxP numpy arrays representing the X^T X matrices
     XTY_list: length K list of length P numpy arrays representing the X^T Y vectors
-    YTY_list: length K list of floats representing the sample variance of the outcome
-    rho: PxP numpy array representing the effect size correlation matrix
+    YTY_list: length K list of floats representing Y^T Y for each population
+    rho: KxK numpy array representing the cross-population effect size
+        correlation matrix
     population_sizes: list of integers representing the number of samples in
         the GWAS for each population
     L: integer representing the maximum number of causal variants
     scaled_prior_variance: float representing the effect size prior variance,
-        scaled by the residual variance. It's fine to set this to a number 
-        larger than what you expect the squared effect size to be (like the 
+        scaled by the residual variance. It's fine to set this to a number
+        larger than what you expect the squared effect size to be (like the
         default value of 0.2) as long as estimate_prior_variance is set to True
         and estimate_prior_method is not set to None.
     prior_weights: numpy P-array of floats representing the prior probability
         of causality for each variant. Give None to use a uniform prior
-    standardize: boolean, whether to adjust summary statistics to be as if 
+    standardize: boolean, whether to adjust summary statistics to be as if
         genotypes were standardized to have mean 0 and variance 1
-    pop_spec_standardization: boolean, if standardize is True, whether to 
+    pop_spec_standardization: boolean, if standardize is True, whether to
         adjust summary statistics to be as if genotypes were standardized
         separately for each population, or pooled and then standardized
     estimate_residual_variance: boolean, whether to estimate the residual variance,
@@ -555,11 +582,11 @@ def susie_multi_ss(
         $A^{(l)}$ in the manuscript
     estimate_prior_method: string, method to estimate the prior variance. Recommended
         values are 'early_EM' or None
-    pop_spec_effect_priors: boolean, whether to estimate separate prior 
+    pop_spec_effect_priors: boolean, whether to estimate separate prior
         variance parameters for each population
     iter_before_zeroing_effects: integer, number of iterations to run before
-        zeroing out component-population pairs (or components if 
-        pop_spec_effect_priors is False) that have a lower likelihood than a 
+        zeroing out component-population pairs (or components if
+        pop_spec_effect_priors is False) that have a lower likelihood than a
         null model
     prior_tol: float which places a filter on the minimum prior variance
         for a component to be included when estimating PIPs
@@ -568,32 +595,43 @@ def susie_multi_ss(
         are returned if the ELBO increases by less than tol in an iteration
     verbose: boolean which indicates if an progress bar should be displayed
     R_list: length K list of PxP numpy arrays representing the LD correlation.
-        If set to None, and min_abs_corr > 0, the LD correlation matrices will
-        be recovered from XTX_list.
+        If None and min_abs_corr > 0 in low_memory_mode, purity cannot be
+        computed because an LD matrix is unavailable.
     coverage: float representing the minimum coverage of credible sets
     min_abs_corr: float representing the minimum absolute correlation between
         any pair of variants in a credible set. For each pair of variants,
-        the max is taken across ancestries. In the case where min_abs_corr = 0,
-        low_memory_mode = True, and recover_R = False, the purity of credible
-        sets will not be calculated. 
+        the max is taken across ancestries. In the case where min_abs_corr = 0
+        and low_memory_mode = True, purity of credible sets is not calculated.
     float_type: numpy float type used. Set to np.float32 to minimize memory
         consumption
-    low_memory_mode: boolean, if True, the input R_list will be modified in place.
-        Decreases memory consumption by a factor of two. BUT, THE INPUT R_list
-        WILL BE OVERWRITTEN. If you need R_list, set low_memory_mode to False
-    recover_R: boolean, if True, the R matrices will be recovered from XTX, 
-        BUT variants with MAC/MAF estimate less than mac_filter/maf_filter will
-        be censored. 
+    low_memory_mode: boolean. If True, input arrays in XTX_list may be modified
+        in place to reduce memory consumption. This can change the provided
+        numpy arrays after susie_multi_ss is complete.
+    variant_ids: length P list of strings representing the variant IDs. If
+        provided, returned credible sets contain a fifth entry with variant IDs
+        for each set.
 
     Returns
     -------
     an object containing results with the following attributes:
-        alpha: L x P numpy array of single-effect regression posterior 
+        pip: length-P numpy array of posterior inclusion probabilities
+        coef: K x P numpy array of posterior effect size estimates for each
+            variant in each population, aggregated across all L single-effect
+            regressions.
+        coef_sd: K x P numpy array of posterior effect size standard deviations
+            for each variant in each population, aggregated across all L
+            single-effect regressions.
+        sets: a list with four entries. The first contains variant indices for
+            each credible set. The second contains set purity values. The third
+            contains coverage values. The fourth contains a boolean indicating
+            whether each set passes purity filtering. If variant_ids is
+            provided, a fifth entry contains the variant IDs for each set.
+        alpha: L x P numpy array of single-effect regression posterior
             inclusion probabilities
         mu: K x L x P numpy array of single-effect regression effect size
             posterior means, conditional on each variant being the causal variant
         mu2: K x K x L x P numpy array of single-effect regression effect size
-            posterior seconds moments, conditional on each variant being the 
+            posterior seconds moments, conditional on each variant being the
             causal variant
         sigma2: length-K numpy array of residual variance estimates
         pi: length-P numpy array of prior inclusion probabilities
@@ -603,92 +641,118 @@ def susie_multi_ss(
         ER2: length-K numpy array of expected squared residuals
         KL: L x 1 numpy array of Kullback-Leibler divergences for each single
             effect regression
-        lbf: L x 1 numpy array of log Bayes factors for each single effect 
+        lbf: L x 1 numpy array of log Bayes factors for each single effect
             regression
         converged: boolean indicating whether the algorithm converged
     """
 
-    #check input dimensions
+    # check input dimensions
     if len(XTX_list) != len(XTY_list):
         raise ValueError("XTX_list and XTY_list must have the same length")
     if not np.all([XTX.shape[1] == XTX_list[0].shape[1] for XTX in XTX_list]):
-        raise ValueError("all matrices in XTX_list must have the same number of columns")
-    if not np.all([XTX.shape[0] == XTY.shape[0] for (XTX, XTY) in zip(XTX_list, XTY_list)]):
-        raise ValueError("each XTX_list[i] and XTY_list[i] must have matching dimensions")
+        raise ValueError(
+            "all matrices in XTX_list must have the same number of columns"
+        )
+    if not np.all(
+        [XTX.shape[0] == XTY.shape[0] for (XTX, XTY) in zip(XTX_list, XTY_list)]
+    ):
+        raise ValueError(
+            "each XTX_list[i] and XTY_list[i] must have matching dimensions"
+        )
     if prior_weights is not None:
         prior_weights = prior_weights.astype(float_type)
 
     if np.any([np.any(np.isnan(XTX)) for XTX in XTX_list]):
         raise ValueError("XTX_list must not contain NaN values")
-        
-    #compute w_pop (the relative size of each population)
+
+    # compute w_pop (the relative size of each population)
     population_sizes = np.array(population_sizes)
-    w_pop = (population_sizes/ population_sizes.sum()).astype(float_type)
-    
-    #compute rho properties
+    w_pop = (population_sizes / population_sizes.sum()).astype(float_type)
+
+    # compute rho properties
     rho = rho.astype(float_type)
     logdet_rho_sign, logdet_rho = np.linalg.slogdet(rho)
     if logdet_rho_sign <= 0:
         raise ValueError("rho must be positive definite")
 
-    X_l2_arr = np.array([np.diag(XTX) for XTX in XTX_list], dtype = float_type)
+    X_l2_arr = np.array([np.diag(XTX) for XTX in XTX_list], dtype=float_type)
 
     # calculate scaling factors
     if standardize:
-        csd = np.sqrt(X_l2_arr/(np.expand_dims(population_sizes, axis = 1) - 1))
+        csd = np.sqrt(X_l2_arr / (np.expand_dims(population_sizes, axis=1) - 1))
         if not pop_spec_standardization:
             csd = csd.T.dot(w_pop)
-            csd = csd * np.ones((len(XTX_list), csd.shape[0]), dtype = float_type)
+            csd = csd * np.ones((len(XTX_list), csd.shape[0]), dtype=float_type)
         for pop_i in range(len(XTX_list)):
-            XTX_list[pop_i] *= (1 / csd[pop_i, :])
-            XTX_list[pop_i] *= (1 / np.expand_dims(csd[pop_i, :], 1))
+            XTX_list[pop_i] *= 1 / csd[pop_i, :]
+            XTX_list[pop_i] *= 1 / np.expand_dims(csd[pop_i, :], 1)
             XTY_list[pop_i] = XTY_list[pop_i] / csd[pop_i, :]
-        X_l2_arr = np.array([np.diag(XTX) for XTX in XTX_list], dtype = float_type)
+        X_l2_arr = np.array([np.diag(XTX) for XTX in XTX_list], dtype=float_type)
     else:
-        csd = np.ones((len(XTX_list), XTX_list[0].shape[1]), dtype = float_type)
-    varY = np.array([YTY/(n-1) for (YTY, n) in zip(YTY_list, population_sizes)], dtype = float_type)
+        csd = np.ones((len(XTX_list), XTX_list[0].shape[1]), dtype=float_type)
+    varY = np.array(
+        [YTY / (n - 1) for (YTY, n) in zip(YTY_list, population_sizes)],
+        dtype=float_type,
+    )
     varY_pooled = (np.sum(YTY_list) / (np.sum(population_sizes) - 1)).astype(float_type)
     residual_variance = varY
 
-    #init setup
+    # init setup
     p = XTX_list[0].shape[1]
 
-    if np.isscalar(scaled_prior_variance) and standardize and not (0 < scaled_prior_variance <= 1):
-        raise ValueError("scaled_prior_variance must be in (0, 1] when scalar and standardize=True")
+    if (
+        np.isscalar(scaled_prior_variance)
+        and standardize
+        and not (0 < scaled_prior_variance <= 1)
+    ):
+        raise ValueError(
+            "scaled_prior_variance must be in (0, 1] when scalar and standardize=True"
+        )
     if prior_weights is None:
-        prior_weights = np.zeros(p, dtype=float_type) + 1.0/p
+        prior_weights = np.zeros(p, dtype=float_type) + 1.0 / p
     else:
         prior_weights = (prior_weights / np.sum(prior_weights)).astype(float_type)
     if prior_weights.shape[0] != p:
-        raise ValueError("prior_weights must have length equal to the number of variants")
-    if p<L: L=p
+        raise ValueError(
+            "prior_weights must have length equal to the number of variants"
+        )
+    if p < L:
+        L = p
 
     # initialize s, which tracks the current model parameter estimates
     s = S(
-        population_sizes, L, XTX_list, scaled_prior_variance, residual_variance,
-        varY_pooled, prior_weights, float_type = float_type
+        population_sizes,
+        L,
+        XTX_list,
+        scaled_prior_variance,
+        residual_variance,
+        varY_pooled,
+        prior_weights,
+        float_type=float_type,
     )
 
-    elbo = np.zeros(max_iter+1) + np.nan
+    elbo = np.zeros(max_iter + 1) + np.nan
     elbo[0] = -np.inf
     check_null_threshold = 0.0
-    
+
     ### start iterations ###
     tqdm_iter = tqdm(list(range(max_iter)), disable=not verbose, file=sys.stdout)
     for i in tqdm_iter:
-        tqdm_iter.set_description('iteration %d/%d'%(i+1, max_iter))
+        tqdm_iter.set_description("iteration %d/%d" % (i + 1, max_iter))
 
         # set the prior variance estimation method for this iteration
-        if estimate_prior_method == 'early_EM':
-            if i == 0: 
+        if estimate_prior_method == "early_EM":
+            if i == 0:
                 current_estimate_prior_method = None
             else:
-                current_estimate_prior_method = 'early_EM'
-        elif (estimate_prior_method is not None) and (estimate_prior_method.split('_')[-1] == 'init'):
+                current_estimate_prior_method = "early_EM"
+        elif (estimate_prior_method is not None) and (
+            estimate_prior_method.split("_")[-1] == "init"
+        ):
             if i == 0:
-                current_estimate_prior_method = estimate_prior_method.split('_')[0]
+                current_estimate_prior_method = estimate_prior_method.split("_")[0]
             else:
-                current_estimate_prior_method = 'EM'
+                current_estimate_prior_method = "EM"
         else:
             current_estimate_prior_method = estimate_prior_method
 
@@ -699,56 +763,81 @@ def susie_multi_ss(
 
         # update all L single effect regressions. s is modified in place.
         update_each_effect(
-            XTX_list, XTY_list, s, X_l2_arr, w_pop,
+            XTX_list,
+            XTY_list,
+            s,
+            X_l2_arr,
+            w_pop,
             rho,
-            estimate_prior_variance, current_estimate_prior_method,
-            check_null_threshold = current_check_null_threshold,
-            pop_spec_effect_priors = pop_spec_effect_priors,
-            float_type = float_type
+            estimate_prior_variance,
+            current_estimate_prior_method,
+            check_null_threshold=current_check_null_threshold,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            float_type=float_type,
         )
 
-        # update the ER2 parameter of s. Used by get_objective and 
+        # update the ER2 parameter of s. Used by get_objective and
         # estimate_resdiaul_variance_func
         s.ER2 = update_ER2(XTX_list, XTY_list, YTY_list, s, X_l2_arr)
 
         # update the ELBO and check for convergence
-        elbo[i+1] = get_objective(XTX_list, XTY_list, s, YTY_list, X_l2_arr)
+        elbo[i + 1] = get_objective(XTX_list, XTY_list, s, YTY_list, X_l2_arr)
         tqdm_iter.set_postfix(objective="{:.6f}".format(elbo[i]))
-        if ((elbo[i+1] - elbo[i]) < tol) and (i >= (iter_before_zeroing_effects + 1)):
+        if ((elbo[i + 1] - elbo[i]) < tol) and (i >= (iter_before_zeroing_effects + 1)):
             s.converged = True
             tqdm_iter.close()
             break
 
         if estimate_residual_variance:
             s.sigma2 = estimate_residual_variance_func(
-                XTX_list, XTY_list, YTY_list, s, X_l2_arr, population_sizes, 
-                float_type = float_type
+                XTX_list,
+                XTY_list,
+                YTY_list,
+                s,
+                X_l2_arr,
+                population_sizes,
+                float_type=float_type,
             )
             if np.any(s.sigma2 < 0):
-                print('minimum residual variance less than 0. Is there mismatch between the correlation matrix and association statistics?')
+                print(
+                    "minimum residual variance less than 0. Is there mismatch between the correlation matrix and association statistics?"
+                )
 
-    elbo = elbo[1:i+2] # Remove first (infinite) entry, and trailing NAs.
+    elbo = elbo[1 : i + 2]  # Remove first (infinite) entry, and trailing NAs.
     s.elbo = elbo
-    s.niter = i+1
+    s.niter = i + 1
 
     if not s.converged:
-        print('IBSS algorithm did not converge in %d iterations'%(max_iter))
-        
+        print("IBSS algorithm did not converge in %d iterations" % (max_iter))
+
     s.fitted = s.Xr_list
 
     s.pip = susie_get_pip(s, prior_tol=prior_tol)
-    s.coef = np.array([np.squeeze(np.sum(s.mu[k] * s.alpha, axis=0) / csd[k, :]) for k in range(len(XTX_list))])
-    s.coef_sd = np.array([(np.squeeze(np.sqrt(np.sum(s.alpha * s.mu2[k, k] - (s.alpha*s.mu[k])**2, axis=0)) / csd[k, :])) for k in range(len(XTX_list))])
+    s.coef = np.array(
+        [
+            np.squeeze(np.sum(s.mu[k] * s.alpha, axis=0) / csd[k, :])
+            for k in range(len(XTX_list))
+        ]
+    )
+    coef_sd_list = []
+    for k in range(len(XTX_list)):
+        var_k = np.sum(s.alpha * s.mu2[k, k] - (s.alpha * s.mu[k]) ** 2, axis=0)
+        coef_sd_list.append(np.squeeze(np.sqrt(var_k) / csd[k, :]))
+    s.coef_sd = np.array(coef_sd_list)
 
-    if (low_memory_mode and (min_abs_corr > 0)) or (low_memory_mode and recover_R):
+    if low_memory_mode and (min_abs_corr > 0):
         for i in range(len(XTX_list)):
             recover_R_from_XTX(XTX_list[i], X_l2_arr[i])
         R_list = XTX_list
 
     s.sets = susie_get_cs(
-        s = s, R_list = R_list, coverage = coverage, min_abs_corr = min_abs_corr, 
-        dedup = True, n_purity = np.inf, 
-        calculate_purity = (not low_memory_mode) or (min_abs_corr > 0) or recover_R
+        s=s,
+        R_list=R_list,
+        coverage=coverage,
+        min_abs_corr=min_abs_corr,
+        dedup=True,
+        n_purity=np.inf,
+        calculate_purity=(not low_memory_mode) or (min_abs_corr > 0),
     )
 
     s.variant_ids = variant_ids
@@ -760,11 +849,21 @@ def susie_multi_ss(
 
     return s
 
+
 def update_each_effect(
-    XTX_list, XTY_list, s, X_l2_arr, w_pop, rho,
-    estimate_prior_variance=False, estimate_prior_method='optim',
-    check_null_threshold=0.0, pop_spec_effect_priors = True, float_type = np.float32):
-    """ Update each single effect regression
+    XTX_list,
+    XTY_list,
+    s,
+    X_l2_arr,
+    w_pop,
+    rho,
+    estimate_prior_variance=False,
+    estimate_prior_method="optim",
+    check_null_threshold=0.0,
+    pop_spec_effect_priors=True,
+    float_type=np.float32,
+):
+    """Update each single effect regression
 
     This calculates updated single effect regression parameter estimates
 
@@ -791,7 +890,6 @@ def update_each_effect(
     Nothing. S is modified in place.
     """
 
-        
     if not estimate_prior_variance:
         estimate_prior_method = None
     L = s.alpha.shape[0]
@@ -803,37 +901,62 @@ def update_each_effect(
         # add the estimate of the current effect back to the residualized
         # XTXY vector
         for k in range(len(XTX_list)):
-            s.Xr_list[k] -= XTX_list[k].dot(s.alpha[l] * s.mu[k,l])
+            s.Xr_list[k] -= XTX_list[k].dot(s.alpha[l] * s.mu[k, l])
             R_list.append(XTY_list[k] - s.Xr_list[k])
-        
-        # get the currrent single effect model parameter estimates after 
+
+        # get the currrent single effect model parameter estimates after
         # residualizing all other effects
         res = single_effect_regression(
-            R_list, XTX_list, s.V[:,l], X_l2_arr, w_pop, rho,
-            residual_variance=s.sigma2, prior_weights=s.pi,
-            optimize_V=estimate_prior_method, 
-            check_null_threshold=check_null_threshold, 
-            pop_spec_effect_priors = pop_spec_effect_priors,
-            alpha = s.alpha[l,:], mu2 = s.mu2[:,:,l,:],
-            float_type = float_type
+            R_list,
+            XTX_list,
+            s.V[:, l],
+            X_l2_arr,
+            w_pop,
+            rho,
+            residual_variance=s.sigma2,
+            prior_weights=s.pi,
+            optimize_V=estimate_prior_method,
+            check_null_threshold=check_null_threshold,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            alpha=s.alpha[l, :],
+            mu2=s.mu2[:, :, l, :],
+            float_type=float_type,
         )
-              
+
         # Update the variational estimate of the posterior mean.
-        s.mu[:,l,:] = res.mu
-        s.alpha[l,:] = res.alpha
-        s.mu2[:,:,l,:] = res.mu2
-        s.V[:,l] = res.V
+        s.mu[:, l, :] = res.mu
+        s.alpha[l, :] = res.alpha
+        s.mu2[:, :, l, :] = res.mu2
+        s.V[:, l] = res.V
         s.lbf[l] = res.lbf_model
-        s.KL[l] = -res.lbf_model + SER_posterior_e_loglik(X_l2_arr, R_list, s.sigma2, res.mu * res.alpha, res.mu2[range(num_pop), range(num_pop)] * res.alpha)
+        s.KL[l] = -res.lbf_model + SER_posterior_e_loglik(
+            X_l2_arr,
+            R_list,
+            s.sigma2,
+            res.mu * res.alpha,
+            res.mu2[range(num_pop), range(num_pop)] * res.alpha,
+        )
         for k in range(len(XTX_list)):
-            s.Xr_list[k] += XTX_list[k].dot(s.alpha[l] * s.mu[k,l])
+            s.Xr_list[k] += XTX_list[k].dot(s.alpha[l] * s.mu[k, l])
+
 
 def single_effect_regression(
-    XTY_list, XTX_list, V, X_l2_arr, w_pop, rho,
-    residual_variance, prior_weights=None, optimize_V=None, 
-    check_null_threshold=0,  pop_spec_effect_priors = True,
-    alpha = None, mu2 = None, float_type = np.float32):
-    """ Fit a multi-population single effect regression model
+    XTY_list,
+    XTX_list,
+    V,
+    X_l2_arr,
+    w_pop,
+    rho,
+    residual_variance,
+    prior_weights=None,
+    optimize_V=None,
+    check_null_threshold=0,
+    pop_spec_effect_priors=True,
+    alpha=None,
+    mu2=None,
+    float_type=np.float32,
+):
+    """Fit a multi-population single effect regression model
 
     Parameters:
     -----------
@@ -843,7 +966,7 @@ def single_effect_regression(
     X_l2_arr: length K numpy array of floats representing the diagonal of X^T X
     w_pop: length K numpy array of floats representing the relative size of each population
     rho: PxP numpy array representing the effect size correlation matrix
-    residual_variance: length K numpy array of floats representing the residual 
+    residual_variance: length K numpy array of floats representing the residual
         variance in each population
     prior_weights: length P numpy array of floats representing the prior probability
         of causality for each variant
@@ -868,35 +991,52 @@ def single_effect_regression(
             on each variant being the causal variant
         mu2: K x K x P numpy array of single effect regression effect size second
             moments conditional on each variant being the causal variant
-        lbf: K x P numpy array representing the log Bayes factor for each 
+        lbf: K x P numpy array representing the log Bayes factor for each
             variant being the causal variant
-        lbf_model: float representing the log Bayes factor for the model, 
+        lbf_model: float representing the log Bayes factor for the model,
             aggregating over variants
         V: length K numpy array of floats representing the effect size prior
     """
-    
-    compute_lbf_params = (XTY_list, XTX_list, X_l2_arr, rho,
-        residual_variance, False, float_type)
 
-    if optimize_V not in ['EM', 'EM_corrected', None]:
-        V = optimize_prior_variance(
-            optimize_V, prior_weights, rho.shape[0], 
-            compute_lbf_params=compute_lbf_params, alpha=alpha, post_mean2=mu2, 
-            w_pop=w_pop, check_null_threshold=check_null_threshold, 
-            pop_spec_effect_priors = pop_spec_effect_priors, current_V = V,
-            float_type = float_type
-        )
-        
-    # compute the log Bayes factor for each variant being the causal variant 
-    # and posterior mean estimates for each variant  under the assumption 
-    # that it is the causal variant
-    lbf, post_mean, post_mean2 = compute_lbf(
-        V = V, XTY_list = XTY_list, XTX_list = XTX_list, X_l2_arr = X_l2_arr, 
-        rho = rho, residual_variance = residual_variance, return_moments=True, 
-        float_type = float_type
+    compute_lbf_params = (
+        XTY_list,
+        XTX_list,
+        X_l2_arr,
+        rho,
+        residual_variance,
+        False,
+        float_type,
     )
 
-    
+    if optimize_V not in ["EM", "EM_corrected", None]:
+        V = optimize_prior_variance(
+            optimize_V,
+            prior_weights,
+            rho.shape[0],
+            compute_lbf_params=compute_lbf_params,
+            alpha=alpha,
+            post_mean2=mu2,
+            w_pop=w_pop,
+            check_null_threshold=check_null_threshold,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            current_V=V,
+            float_type=float_type,
+        )
+
+    # compute the log Bayes factor for each variant being the causal variant
+    # and posterior mean estimates for each variant  under the assumption
+    # that it is the causal variant
+    lbf, post_mean, post_mean2 = compute_lbf(
+        V=V,
+        XTY_list=XTY_list,
+        XTX_list=XTX_list,
+        X_l2_arr=X_l2_arr,
+        rho=rho,
+        residual_variance=residual_variance,
+        return_moments=True,
+        float_type=float_type,
+    )
+
     # compute posterior inclusion probabilities (not combined over single effect regressions)
     maxlbf = np.max(lbf)
     w = np.exp(lbf - maxlbf)
@@ -904,21 +1044,27 @@ def single_effect_regression(
     weighted_sum_w = w_weighted.sum()
     alpha = w_weighted / weighted_sum_w
     lbf_model = maxlbf + np.log(weighted_sum_w)
-        
-    if optimize_V in ['EM', 'EM_corrected']:
-        V = optimize_prior_variance(
-            optimize_V, prior_weights, rho.shape[0], 
-            compute_lbf_params=compute_lbf_params, alpha=alpha, 
-            post_mean2=post_mean2, w_pop=w_pop, 
-            check_null_threshold=check_null_threshold, 
-            pop_spec_effect_priors = pop_spec_effect_priors, 
-            float_type = float_type
-        )
-        
-    res = SER_RESULTS(alpha=alpha, mu=post_mean, mu2=post_mean2, lbf=lbf, lbf_model=lbf_model, V=V)
 
+    if optimize_V in ["EM", "EM_corrected"]:
+        V = optimize_prior_variance(
+            optimize_V,
+            prior_weights,
+            rho.shape[0],
+            compute_lbf_params=compute_lbf_params,
+            alpha=alpha,
+            post_mean2=post_mean2,
+            w_pop=w_pop,
+            check_null_threshold=check_null_threshold,
+            pop_spec_effect_priors=pop_spec_effect_priors,
+            float_type=float_type,
+        )
+
+    res = SER_RESULTS(
+        alpha=alpha, mu=post_mean, mu2=post_mean2, lbf=lbf, lbf_model=lbf_model, V=V
+    )
 
     return res
+
 
 def loglik(V, prior_weights, compute_lbf_params):
     lbf = compute_lbf(V, *compute_lbf_params)
@@ -929,57 +1075,92 @@ def loglik(V, prior_weights, compute_lbf_params):
     loglik = maxlbf + np.log(weighted_sum_w)
     return loglik
 
-def optimize_prior_variance(
-    optimize_V, prior_weights, num_pops, compute_lbf_params=None, alpha=None, post_mean2=None, w_pop=None, check_null_threshold=0, 
-    pop_spec_effect_priors = False, current_V = None, float_type = np.float32, loglik_function = loglik):
 
-    if optimize_V == 'optim':
+def optimize_prior_variance(
+    optimize_V,
+    prior_weights,
+    num_pops,
+    compute_lbf_params=None,
+    alpha=None,
+    post_mean2=None,
+    w_pop=None,
+    check_null_threshold=0,
+    pop_spec_effect_priors=False,
+    current_V=None,
+    float_type=np.float32,
+    loglik_function=loglik,
+):
+    if optimize_V == "optim":
         if pop_spec_effect_priors:
-            raise Exception('estimate_prior_method="optim" with ' +
-                            'pop_spec_effect_priors=True has not been implemented')
+            raise Exception(
+                'estimate_prior_method="optim" with '
+                + "pop_spec_effect_priors=True has not been implemented"
+            )
         else:
-            neg_loglik_logscale = lambda lV: -loglik_function(np.array([np.exp(lV) for i in range(num_pops)]), prior_weights, compute_lbf_params)
-            opt_obj = minimize_scalar(neg_loglik_logscale, bounds=(-30,15))
+            neg_loglik_logscale = lambda lV: -loglik_function(
+                np.array([np.exp(lV) for i in range(num_pops)]),
+                prior_weights,
+                compute_lbf_params,
+            )
+            opt_obj = minimize_scalar(neg_loglik_logscale, bounds=(-30, 15))
             lV = opt_obj.x
             V = np.exp(lV)
-    elif optimize_V in ['EM', 'early_EM']:
-        V = np.array([np.sum(alpha * post_mean2[i, i]) for i in range(num_pops)], dtype=float_type)
+    elif optimize_V in ["EM", "early_EM"]:
+        V = np.array(
+            [np.sum(alpha * post_mean2[i, i]) for i in range(num_pops)],
+            dtype=float_type,
+        )
         if not pop_spec_effect_priors:
             V = (w_pop.dot(V)).astype(float_type)
-    elif optimize_V == 'grid':
+    elif optimize_V == "grid":
         if pop_spec_effect_priors:
-            raise Exception('estimate_prior_method="grid" with ' +
-                            'pop_spec_effect_priors=True has not been implemented')
+            raise Exception(
+                'estimate_prior_method="grid" with '
+                + "pop_spec_effect_priors=True has not been implemented"
+            )
         else:
             V_arr = np.logspace(-7, -1, 13)
-            llik_arr = np.array([loglik_function(V, prior_weights, compute_lbf_params) for V in V_arr])
+            llik_arr = np.array(
+                [loglik_function(V, prior_weights, compute_lbf_params) for V in V_arr]
+            )
             V = V_arr[np.argmax(llik_arr)]
     else:
-        raise ValueError('unknown optimization method')
+        raise ValueError("unknown optimization method")
 
     if not pop_spec_effect_priors:
-        V = V * np.ones(post_mean2.shape[0], dtype = float_type)
+        V = V * np.ones(post_mean2.shape[0], dtype=float_type)
         # set V exactly 0 if that beats the numerical value by check_null_threshold in loglik.
-        delta_loglik = loglik_function(0, prior_weights, compute_lbf_params) + check_null_threshold - loglik_function(V, prior_weights, compute_lbf_params)
+        delta_loglik = (
+            loglik_function(0, prior_weights, compute_lbf_params)
+            + check_null_threshold
+            - loglik_function(V, prior_weights, compute_lbf_params)
+        )
         if np.isclose(delta_loglik, 0) or delta_loglik >= 0:
-            V=0
+            V = 0
     else:
         if check_null_threshold == (-1 * np.inf):
             return V
         elif np.all(np.isclose(V, 0)):
             return 0
-        # Compare our current effect prior to null models 
+        # Compare our current effect prior to null models
         else:
             V_list = [V]
             # zero out each population, one at a time
             for i in range(num_pops):
-                if not np.isclose(V[i],0):
+                if not np.isclose(V[i], 0):
                     V_copy = V.copy()
                     V_copy[i] = 0
                     V_list.append(V_copy)
             V_list.append(np.array([np.zeros(num_pops, dtype=float_type)]))
-        llik_arr = np.array([loglik_function(np.array(V), prior_weights, compute_lbf_params) for V in V_list])
-        llik_arr = llik_arr + np.array([0] + [check_null_threshold for i in range(len(V_list) - 1)])
+        llik_arr = np.array(
+            [
+                loglik_function(np.array(V), prior_weights, compute_lbf_params)
+                for V in V_list
+            ]
+        )
+        llik_arr = llik_arr + np.array(
+            [0] + [check_null_threshold for i in range(len(V_list) - 1)]
+        )
         V = V_list[np.argmax(llik_arr)]
     if isinstance(V, np.ndarray):
         V[V < 0] = 0
@@ -988,11 +1169,18 @@ def optimize_prior_variance(
 
     return V
 
+
 def compute_lbf(
-    V, XTY_list, XTX_list, X_l2_arr, rho,
-    residual_variance, return_moments=False,  
-    float_type = np.float32):
-    
+    V,
+    XTY_list,
+    XTX_list,
+    X_l2_arr,
+    rho,
+    residual_variance,
+    return_moments=False,
+    float_type=np.float32,
+):
+
     num_variables = XTX_list[0].shape[0]
     num_pops = len(XTX_list)
 
@@ -1005,14 +1193,14 @@ def compute_lbf(
     elif np.any(np.isclose(V, 0)):
         nonzero_pops = np.flatnonzero(~np.isclose(V, 0))
         lbf_out = compute_lbf(
-            V = V[nonzero_pops], 
-            XTY_list = [XTY_list[i] for i in nonzero_pops], 
-            XTX_list = [XTX_list[i] for i in nonzero_pops], 
-            X_l2_arr = X_l2_arr[nonzero_pops], 
-            rho = rho[nonzero_pops, :][:, nonzero_pops],
-            residual_variance = residual_variance[nonzero_pops], 
-            return_moments = return_moments, 
-            float_type = float_type
+            V=V[nonzero_pops],
+            XTY_list=[XTY_list[i] for i in nonzero_pops],
+            XTX_list=[XTX_list[i] for i in nonzero_pops],
+            X_l2_arr=X_l2_arr[nonzero_pops],
+            rho=rho[nonzero_pops, :][:, nonzero_pops],
+            residual_variance=residual_variance[nonzero_pops],
+            return_moments=return_moments,
+            float_type=float_type,
         )
         if return_moments:
             post_mean = np.zeros((num_pops, num_variables), dtype=float_type)
@@ -1024,71 +1212,85 @@ def compute_lbf(
             lbf = lbf_out
 
     else:
-        XTY = np.ascontiguousarray(np.stack(XTY_list, axis = 1))
+        XTY = np.ascontiguousarray(np.stack(XTY_list, axis=1))
         if return_moments:
             try:
                 lbf, post_mean, post_mean2 = compute_lbf_and_moments(
-                    V = V, XTY = XTY, X_l2_arr = X_l2_arr, rho = rho,
-                    residual_variance = residual_variance, float_type = float_type
+                    V=V,
+                    XTY=XTY,
+                    X_l2_arr=X_l2_arr,
+                    rho=rho,
+                    residual_variance=residual_variance,
+                    float_type=float_type,
                 )
             except:
                 lbf, post_mean, post_mean2 = compute_lbf_and_moments_safe(
-                    V = V, XTY = XTY, X_l2_arr = X_l2_arr, rho = rho,
-                    residual_variance = residual_variance, float_type = float_type
+                    V=V,
+                    XTY=XTY,
+                    X_l2_arr=X_l2_arr,
+                    rho=rho,
+                    residual_variance=residual_variance,
+                    float_type=float_type,
                 )
         else:
             lbf = compute_lbf_no_moments(
-                V = V, XTY = XTY, X_l2_arr = X_l2_arr, rho = rho,
-                residual_variance = residual_variance, float_type = float_type
+                V=V,
+                XTY=XTY,
+                X_l2_arr=X_l2_arr,
+                rho=rho,
+                residual_variance=residual_variance,
+                float_type=float_type,
             )
     if return_moments:
         return lbf, post_mean, post_mean2
     else:
         return lbf
 
+
 @numba.jit(nopython=True, cache=True)
 def compute_lbf_no_moments(
-    V, XTY, X_l2_arr, rho, residual_variance, float_type = np.float32):
-    
-    
+    V, XTY, X_l2_arr, rho, residual_variance, float_type=np.float32
+):
+
     num_pops = XTY.shape[1]
     num_variables = XTY.shape[0]
 
     lbf = np.zeros(num_variables, dtype=float_type)
-    
+
     YT_invD_Z = XTY / residual_variance
 
-    #compute a (the effects covariance matrix) and its inverse and log-determinant
+    # compute a (the effects covariance matrix) and its inverse and log-determinant
     A = rho * np.sqrt(np.outer(V, V))
     inv_A = np.linalg.inv(A)
     logdet_A_sign, logdetA = np.linalg.slogdet(A)
 
     for i in range(num_variables):
-    
-        #compute the diagonal of q = z.t * inv(d) * z (this is a diagonal matrix)
-        # this is (n_pop)
-        Q_diag = X_l2_arr[:,i]/residual_variance
 
-        #compute log-determinent for inv(a)+q
+        # compute the diagonal of q = z.t * inv(d) * z (this is a diagonal matrix)
+        # this is (n_pop)
+        Q_diag = X_l2_arr[:, i] / residual_variance
+
+        # compute log-determinent for inv(a)+q
         # this is (n_pop, n_pop)
         Ainv_plus_Q = inv_A + np.diag(Q_diag)
         logdet_Ainv_plus_Q_sign, logdet_Ainv_plus_Q = np.linalg.slogdet(Ainv_plus_Q)
-        assert logdet_Ainv_plus_Q_sign>0
-    
-        #compute inv_ainv_plus_q_times_zt_invd_y
-        inv_Ainv_plus_Q_times_ZT_invD_Y = np.linalg.solve(Ainv_plus_Q, YT_invD_Z[i,:])
+        assert logdet_Ainv_plus_Q_sign > 0
 
-        #compute log-bf for this variable
-        lbf_1 = 0.5 * YT_invD_Z[i,:].dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
+        # compute inv_ainv_plus_q_times_zt_invd_y
+        inv_Ainv_plus_Q_times_ZT_invD_Y = np.linalg.solve(Ainv_plus_Q, YT_invD_Z[i, :])
+
+        # compute log-bf for this variable
+        lbf_1 = 0.5 * YT_invD_Z[i, :].dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
         lbf_2 = -0.5 * (logdetA + logdet_Ainv_plus_Q)
         lbf[i] = lbf_1 + lbf_2
-        
+
     return lbf
+
 
 @numba.jit(nopython=True, cache=True)
 def compute_lbf_and_moments(
-    V, XTY, X_l2_arr, rho,
-    residual_variance, float_type = np.float32):
+    V, XTY, X_l2_arr, rho, residual_variance, float_type=np.float32
+):
 
     num_pops = XTY.shape[1]
     num_variables = XTY.shape[0]
@@ -1096,44 +1298,48 @@ def compute_lbf_and_moments(
     lbf = np.zeros(num_variables, dtype=float_type)
     post_mean = np.zeros((num_pops, num_variables), dtype=float_type)
     post_mean2 = np.zeros((num_pops, num_pops, num_variables), dtype=float_type)
-        
 
     YT_invD_Z = XTY / residual_variance
 
-    #compute a (the effects covariance matrix) and its inverse and log-determinant
+    # compute a (the effects covariance matrix) and its inverse and log-determinant
     A = rho * np.sqrt(np.outer(V, V))
     inv_A = np.linalg.inv(A)
     logdet_A_sign, logdetA = np.linalg.slogdet(A)
 
     for i in range(num_variables):
-    
-        #compute the diagonal of q = z.t * inv(d) * z (this is a diagonal matrix)
-        Q_diag = X_l2_arr[:,i] / residual_variance
 
-        #compute log-determinent for inv(a)+q
+        # compute the diagonal of q = z.t * inv(d) * z (this is a diagonal matrix)
+        Q_diag = X_l2_arr[:, i] / residual_variance
+
+        # compute log-determinent for inv(a)+q
         Ainv_plus_Q = inv_A + np.diag(Q_diag)
         logdet_Ainv_plus_Q_sign, logdet_Ainv_plus_Q = np.linalg.slogdet(Ainv_plus_Q)
-        assert logdet_Ainv_plus_Q_sign>0
-    
-        #compute inv_ainv_plus_q_times_zt_invd_y
+        assert logdet_Ainv_plus_Q_sign > 0
+
+        # compute inv_ainv_plus_q_times_zt_invd_y
         inv_Ainv_plus_Q_times_ZT_invD_Y = np.linalg.solve(Ainv_plus_Q, YT_invD_Z[i, :])
 
-        #compute log-bf for this variable
+        # compute log-bf for this variable
         lbf_1 = 0.5 * YT_invD_Z[i, :].dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
         lbf_2 = -0.5 * (logdetA + logdet_Ainv_plus_Q)
         lbf[i] = lbf_1 + lbf_2
 
-        #compute posterior moments for this variable
-        AQ = A*Q_diag
-        post_mean[:,i] = A.dot(YT_invD_Z[i, :]) - AQ.dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
+        # compute posterior moments for this variable
+        AQ = A * Q_diag
+        post_mean[:, i] = A.dot(YT_invD_Z[i, :]) - AQ.dot(
+            inv_Ainv_plus_Q_times_ZT_invD_Y
+        )
         post_covar_i = A - AQ.dot(A) + AQ.dot(np.linalg.solve(Ainv_plus_Q, AQ.T))
-        post_mean2[:, :, i] = np.maximum(post_covar_i + np.outer(post_mean[:,i], post_mean[:,i]), 0)
+        post_mean2[:, :, i] = np.maximum(
+            post_covar_i + np.outer(post_mean[:, i], post_mean[:, i]), 0
+        )
 
     return lbf, post_mean, post_mean2
+
 
 def compute_lbf_and_moments_safe(
-    V, XTY, X_l2_arr, rho,
-    residual_variance, float_type = np.float32):
+    V, XTY, X_l2_arr, rho, residual_variance, float_type=np.float32
+):
 
     num_pops = XTY.shape[1]
     num_variables = XTY.shape[0]
@@ -1141,97 +1347,124 @@ def compute_lbf_and_moments_safe(
     lbf = np.zeros(num_variables, dtype=float_type)
     post_mean = np.zeros((num_pops, num_variables), dtype=float_type)
     post_mean2 = np.zeros((num_pops, num_pops, num_variables), dtype=float_type)
-        
 
     YT_invD_Z = XTY / residual_variance
 
-    #compute a (the effects covariance matrix) and its inverse and log-determinant
+    # compute a (the effects covariance matrix) and its inverse and log-determinant
     A = rho * np.sqrt(np.outer(V, V))
     inv_A = np.linalg.inv(A)
     logdet_A_sign, logdetA = np.linalg.slogdet(A)
 
     for i in range(num_variables):
 
-        #compute the diagonal of q = z.t * inv(d) * z (this is a diagonal matrix)
-        Q_diag = X_l2_arr[:,i]/residual_variance
+        # compute the diagonal of q = z.t * inv(d) * z (this is a diagonal matrix)
+        Q_diag = X_l2_arr[:, i] / residual_variance
 
-        #compute log-determinent for inv(a)+q
+        # compute log-determinent for inv(a)+q
         Ainv_plus_Q = inv_A + np.diag(Q_diag)
         logdet_Ainv_plus_Q_sign, logdet_Ainv_plus_Q = np.linalg.slogdet(Ainv_plus_Q)
-        assert logdet_Ainv_plus_Q_sign>0
+        assert logdet_Ainv_plus_Q_sign > 0
 
-        #compute inv_ainv_plus_q_times_zt_invd_y
+        # compute inv_ainv_plus_q_times_zt_invd_y
         inv_Ainv_plus_Q_times_ZT_invD_Y = np.linalg.solve(Ainv_plus_Q, YT_invD_Z[i, :])
 
-        #compute log-bf for this variable
+        # compute log-bf for this variable
         lbf_1 = 0.5 * YT_invD_Z[i, :].dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
         lbf_2 = -0.5 * (logdetA + logdet_Ainv_plus_Q)
         lbf[i] = lbf_1 + lbf_2
 
-        #compute posterior moments for this variable
-        AQ = A*Q_diag
-        post_mean[:,i] = A.dot(YT_invD_Z[i, :]) - AQ.dot(inv_Ainv_plus_Q_times_ZT_invD_Y)
+        # compute posterior moments for this variable
+        AQ = A * Q_diag
+        post_mean[:, i] = A.dot(YT_invD_Z[i, :]) - AQ.dot(
+            inv_Ainv_plus_Q_times_ZT_invD_Y
+        )
         post_covar_i = A - AQ.dot(A) + AQ.dot(np.linalg.solve(Ainv_plus_Q, AQ.T))
-        post_mean2[:, :, i] = post_covar_i + np.outer(post_mean[:,i], post_mean[:,i])
+        post_mean2[:, :, i] = post_covar_i + np.outer(post_mean[:, i], post_mean[:, i])
 
     return lbf, post_mean, post_mean2
+
 
 def get_objective(XTX_list, XTY_list, s, YTY_list, X_l2_arr):
     return Eloglik(XTX_list, XTY_list, s, YTY_list, X_l2_arr) - np.sum(s.KL)
 
+
 def Eloglik(XTX_list, XTY_list, s, YTY_list, X_l2_arr):
-    result = -0.5 * s.n.dot(np.log(2*np.pi*s.sigma2))
+    result = -0.5 * s.n.dot(np.log(2 * np.pi * s.sigma2))
     for i in range(len(XTX_list)):
-        result -= 0.5/s.sigma2[i] * s.ER2[i]
+        result -= 0.5 / s.sigma2[i] * s.ER2[i]
     return result
+
 
 def update_ER2(XTX_list, XTY_list, YTY_list, s, X_l2_arr):
     ER2 = np.zeros(len(XTX_list))
     for i in range(len(XTX_list)):
         ER2[i] = get_ER2(
-            XTX_list[i], XTY_list[i], YTY_list[i], s.alpha, s.mu[i], 
-            s.mu2[i, i], X_l2_arr[i]
+            XTX_list[i],
+            XTY_list[i],
+            YTY_list[i],
+            s.alpha,
+            s.mu[i],
+            s.mu2[i, i],
+            X_l2_arr[i],
         )
     return ER2
 
+
 def get_ER2(XTX, XTY, YTY, alpha, mu, mu2, X_l2):
-    B = alpha * mu # beta should be lxp
+    B = alpha * mu  # beta should be lxp
     XB2 = np.sum(np.dot(B, XTX) * B)
-    betabar = np.sum(B, axis = 0)
+    betabar = np.sum(B, axis=0)
     postb2 = alpha * mu2
 
-    result = YTY - 2 * betabar.dot(XTY) + betabar.dot(np.dot(XTX, betabar)) - XB2 + np.sum(X_l2 * postb2) 
-    return result     
+    result = (
+        YTY
+        - 2 * betabar.dot(XTY)
+        + betabar.dot(np.dot(XTX, betabar))
+        - XB2
+        + np.sum(X_l2 * postb2)
+    )
+    return result
+
 
 def SER_posterior_e_loglik(X_l2_arr, XTY_list, s2, Eb, Eb2):
     result = 0
     for i in range(len(X_l2_arr)):
-        result -= .5 / s2[i] * (-2 * XTY_list[i].dot(Eb[i]) + X_l2_arr[i].dot(Eb2[i]))
+        result -= 0.5 / s2[i] * (-2 * XTY_list[i].dot(Eb[i]) + X_l2_arr[i].dot(Eb2[i]))
     return result
 
+
 def estimate_residual_variance_func(
-        XTX_list, XTY_list, YTY_list, s, X_l2_arr, population_sizes, 
-        float_type = np.float32):
+    XTX_list, XTY_list, YTY_list, s, X_l2_arr, population_sizes, float_type=np.float32
+):
 
     sigma2_arr = np.zeros(len(XTX_list), dtype=float_type)
     for i in range(len(XTX_list)):
-        sigma2_arr[i] =  s.ER2[i] / population_sizes[i]
+        sigma2_arr[i] = s.ER2[i] / population_sizes[i]
     return sigma2_arr
 
+
 def susie_get_pip(s, prior_tol=1e-9):
-    include_idx = np.any(s.V > prior_tol, axis = 0)
+    include_idx = np.any(s.V > prior_tol, axis=0)
     if not np.any(include_idx):
         return np.zeros(s.alpha.shape[1])
     res = s.alpha[include_idx, :]
-    pips = 1 - np.prod(1-res, axis=0)
+    pips = 1 - np.prod(1 - res, axis=0)
     return pips
 
+
 def susie_get_cs(
-    s, R_list, coverage = 0.95, min_abs_corr = 0.5, dedup = True, n_purity = 100,
-    calculate_purity = True, X_list = None):
+    s,
+    R_list,
+    coverage=0.95,
+    min_abs_corr=0.5,
+    dedup=True,
+    n_purity=100,
+    calculate_purity=True,
+    X_list=None,
+):
 
     if len(s.V.shape) == 2:
-        include_mask = np.any(s.V > 1e-9, axis = 0)
+        include_mask = np.any(s.V > 1e-9, axis=0)
     else:
         include_mask = s.V > 1e-9
 
@@ -1252,15 +1485,26 @@ def susie_get_cs(
         return ([[] for i in range(len(include_mask))], None, None, include_mask)
 
     if calculate_purity:
-        purity = np.array([get_purity_x(cs[i], R_list, min_abs_corr, n_purity, X_list) if include_mask[i] else np.nan for i in range(len(cs))])
+        purity = np.array(
+            [
+                (
+                    get_purity_x(cs[i], R_list, min_abs_corr, n_purity, X_list)
+                    if include_mask[i]
+                    else np.nan
+                )
+                for i in range(len(cs))
+            ]
+        )
         include_mask[purity < min_abs_corr] = False
     else:
         purity = np.array([np.nan for i in range(len(cs))])
 
     return [cs, purity, claimed_coverage, include_mask]
 
+
 def in_CS(alpha, coverage):
     return np.apply_along_axis(in_CS_x, 1, alpha, coverage)
+
 
 def in_CS_x(alpha, coverage):
     n = n_in_CS_x(alpha, coverage)
@@ -1269,26 +1513,32 @@ def in_CS_x(alpha, coverage):
     result[o[:n]] = 1
     return result
 
+
 def n_in_CS(alpha, coverage):
     return np.apply_along_axis(n_in_CS_x, 1, alpha, coverage)
 
+
 def n_in_CS_x(alpha, coverage):
     return np.sum(np.cumsum(np.sort(alpha)[::-1]) < coverage) + 1
+
 
 def get_purity_x(cs, R_list, min_abs_cor, n_purity, X_list):
     if len(cs) > n_purity:
         cs = random.sample(cs.tolist(), n_purity)
     if R_list is None:
-        R_list = [np.corrcoef(X_list[i][:,cs], rowvar = False) for i in range(len(X_list))]
+        R_list = [
+            np.corrcoef(X_list[i][:, cs], rowvar=False) for i in range(len(X_list))
+        ]
     else:
         R_list = [R[cs, :][:, cs] for R in R_list]
     abs_meta_R = functools.reduce(np.maximum, [np.abs(R) for R in R_list])
 
     return np.min(abs_meta_R)
 
+
 def recover_R_from_XTX(XTX, X_l2):
-    assert((XTX[:,np.flatnonzero(X_l2 == 0)] == 0).all())
-    assert((XTX[np.flatnonzero(X_l2 == 0),:] == 0).all())
-    with np.errstate(divide='ignore', invalid = 'ignore'):
+    assert (XTX[:, np.flatnonzero(X_l2 == 0)] == 0).all()
+    assert (XTX[np.flatnonzero(X_l2 == 0), :] == 0).all()
+    with np.errstate(divide="ignore", invalid="ignore"):
         XTX /= np.sqrt(np.nan_to_num(X_l2, 1))
         XTX /= np.sqrt(np.expand_dims(np.nan_to_num(X_l2, 1), 1))

--- a/tests.py
+++ b/tests.py
@@ -2,79 +2,90 @@ import numpy as np
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 import MultiSuSiE
 
-geno_YRI = np.loadtxt('example_data/geno_YRI.txt')
-geno_CEU = np.loadtxt('example_data/geno_CEU.txt')
-geno_JPT = np.loadtxt('example_data/geno_JPT.txt')
+geno_YRI = np.loadtxt("example_data/geno_YRI.txt")
+geno_CEU = np.loadtxt("example_data/geno_CEU.txt")
+geno_JPT = np.loadtxt("example_data/geno_JPT.txt")
 geno_list = [geno_CEU, geno_YRI, geno_JPT]
 
 beta_YRI = np.zeros(40)
 beta_CEU = np.zeros(40)
 beta_JPT = np.zeros(40)
-beta_YRI[10]=.75
-beta_CEU[10]=1
-beta_JPT[10]=.5
-beta_YRI[3]=.5
-beta_CEU[3]=.5
-beta_JPT[3]=.5
-beta_YRI[38]=1
-beta_CEU[38]=0
-beta_JPT[38]=0
+beta_YRI[10] = 0.75
+beta_CEU[10] = 1
+beta_JPT[10] = 0.5
+beta_YRI[3] = 0.5
+beta_CEU[3] = 0.5
+beta_JPT[3] = 0.5
+beta_YRI[38] = 1
+beta_CEU[38] = 0
+beta_JPT[38] = 0
 beta_list = [beta_YRI, beta_CEU, beta_JPT]
 
 rng = np.random.default_rng(1)
-y_list = [geno.dot(beta) + rng.standard_normal(geno.shape[0]) for (geno, beta) in zip(geno_list, beta_list)]
+y_list = [
+    geno.dot(beta) + rng.standard_normal(geno.shape[0])
+    for (geno, beta) in zip(geno_list, beta_list)
+]
 y_list = [y - np.mean(y) for y in y_list]
 
 XTY_list = [geno.T.dot(y) for (geno, y) in zip(geno_list, y_list)]
 XTX_diagonal_list = [np.diagonal(geno.T.dot(geno)) for geno in geno_list]
-with np.errstate(divide='ignore',invalid='ignore'):
-    beta_hat_list = [XTY / XTX_diag for (XTY, XTX_diag) in zip(XTY_list, XTX_diagonal_list)]
+with np.errstate(divide="ignore", invalid="ignore"):
+    beta_hat_list = [
+        XTY / XTX_diag for (XTY, XTX_diag) in zip(XTY_list, XTX_diagonal_list)
+    ]
 
 N_list = [geno.shape[0] for geno in geno_list]
-residuals_list = [np.expand_dims(y, 1) - (geno * beta) for (y, geno, beta) in zip(y_list, geno_list, beta_hat_list)]
-sum_of_squared_residuals_list = [np.sum(resid ** 2, axis = 0) for resid in residuals_list]
-se_list = [np.sqrt(ssr / ((N - 2) * XTX)) for (ssr, N, XTX) in zip(sum_of_squared_residuals_list, N_list, XTX_diagonal_list)]
+residuals_list = [
+    np.expand_dims(y, 1) - (geno * beta)
+    for (y, geno, beta) in zip(y_list, geno_list, beta_hat_list)
+]
+sum_of_squared_residuals_list = [np.sum(resid**2, axis=0) for resid in residuals_list]
+se_list = [
+    np.sqrt(ssr / ((N - 2) * XTX))
+    for (ssr, N, XTX) in zip(sum_of_squared_residuals_list, N_list, XTX_diagonal_list)
+]
 
-with np.errstate(divide='ignore',invalid='ignore'):
-    R_list = [np.corrcoef(geno, rowvar = False) for geno in geno_list]
+with np.errstate(divide="ignore", invalid="ignore"):
+    R_list = [np.corrcoef(geno, rowvar=False) for geno in geno_list]
 
 YTY_list = [y.dot(y) for y in y_list]
-varY_list = [np.var(y, ddof = 1) for y in y_list]
+varY_list = [np.var(y, ddof=1) for y in y_list]
 rho = np.array([[1, 0.75, 0.75], [0.75, 1, 0.75], [0.75, 0.75, 1]])
 common_multisusie_kwargs = dict(
-    rho = rho,
-    L = 10,
-    scaled_prior_variance = 0.2,
-    min_abs_corr = 0,
-    float_type = np.float64,
-    estimate_prior_method = 'EM',
-    pop_spec_effect_priors = False,
-    iter_before_zeroing_effects = 0,
+    rho=rho,
+    L=10,
+    scaled_prior_variance=0.2,
+    min_abs_corr=0,
+    float_type=np.float64,
+    estimate_prior_method="EM",
+    pop_spec_effect_priors=False,
+    iter_before_zeroing_effects=0,
 )
 
 # TEST 1: test that summary statistic and individual level MultiSuSiE give identical results
 ss_fit = MultiSuSiE.multisusie_rss(
-    b_list = beta_hat_list,
-    s_list = se_list,
-    R_list = R_list,
-    varY_list = varY_list,
-    population_sizes = N_list,
-    low_memory_mode = False,
-    recover_R = False,
-    single_population_mac_thresh = 0,
+    b_list=beta_hat_list,
+    s_list=se_list,
+    R_list=R_list,
+    varY_list=varY_list,
+    population_sizes=N_list,
+    low_memory_mode=False,
+    recover_R=False,
+    single_population_mac_thresh=0,
     **common_multisusie_kwargs,
 )
 indiv_fit = MultiSuSiE.multisusie(
-    X_list = geno_list,
-    Y_list = y_list,
-    standardize = False,
+    X_list=geno_list,
+    Y_list=y_list,
+    standardize=False,
     **common_multisusie_kwargs,
 )
 
-assert(np.max(np.abs(ss_fit.pip - indiv_fit.pip)) < 1e-10)
+assert np.max(np.abs(ss_fit.pip - indiv_fit.pip)) < 1e-10
 
 
 # TEST 2: test that low_memory mode=False does not mutate anything
@@ -82,21 +93,48 @@ R_list_copy = [R.copy() for R in R_list]
 beta_hat_list_copy = [b.copy() for b in beta_hat_list]
 se_list_copy = [se.copy() for se in se_list]
 ss_fit = MultiSuSiE.multisusie_rss(
-    b_list = beta_hat_list,
-    s_list = se_list,
-    R_list = R_list,
-    varY_list = varY_list,
-    population_sizes = N_list,
-    single_population_mac_thresh = 5,
-    low_memory_mode = False,
+    b_list=beta_hat_list,
+    s_list=se_list,
+    R_list=R_list,
+    varY_list=varY_list,
+    population_sizes=N_list,
+    single_population_mac_thresh=5,
+    low_memory_mode=False,
     **common_multisusie_kwargs,
 )
-assert(all([np.nanmax(np.abs(R_copy - R)) < 1e-10 for (R_copy, R) in zip(R_list_copy, R_list)]))
-assert(all([(np.isnan(R_copy) == np.isnan(R)).all() for (R_copy, R) in zip(R_list_copy, R_list)]))
-assert(all([np.nanmax(np.abs(beta_hat_copy - beta_hat)) < 1e-10 for (beta_hat_copy, beta_hat) in zip(beta_hat_list_copy, beta_hat_list)]))
-assert(all([(np.isnan(beta_hat_copy) == np.isnan(beta_hat)).all() for (beta_hat_copy, beta_hat) in zip(beta_hat_list_copy, beta_hat_list)]))
-assert(all([np.nanmax(np.abs(se_copy - se)) < 1e-10 for (se_copy, se) in zip(se_list_copy, se_list)]))
-assert(all([(np.isnan(se_copy) == np.isnan(se)).all() for (se_copy, se) in zip(se_list_copy, se_list)]))
+assert all(
+    [np.nanmax(np.abs(R_copy - R)) < 1e-10 for (R_copy, R) in zip(R_list_copy, R_list)]
+)
+assert all(
+    [
+        (np.isnan(R_copy) == np.isnan(R)).all()
+        for (R_copy, R) in zip(R_list_copy, R_list)
+    ]
+)
+assert all(
+    [
+        np.nanmax(np.abs(beta_hat_copy - beta_hat)) < 1e-10
+        for (beta_hat_copy, beta_hat) in zip(beta_hat_list_copy, beta_hat_list)
+    ]
+)
+assert all(
+    [
+        (np.isnan(beta_hat_copy) == np.isnan(beta_hat)).all()
+        for (beta_hat_copy, beta_hat) in zip(beta_hat_list_copy, beta_hat_list)
+    ]
+)
+assert all(
+    [
+        np.nanmax(np.abs(se_copy - se)) < 1e-10
+        for (se_copy, se) in zip(se_list_copy, se_list)
+    ]
+)
+assert all(
+    [
+        (np.isnan(se_copy) == np.isnan(se)).all()
+        for (se_copy, se) in zip(se_list_copy, se_list)
+    ]
+)
 
 
 # TEST 3: test that recover_R_from_XTX recovers XTX
@@ -105,11 +143,7 @@ XTX_list = []
 XTY_list = []
 for i in range(len(R_list)):
     XTY = MultiSuSiE.recover_XTX_and_XTY(
-        beta_hat_list[i],
-        se_list[i],
-        R_list_copy[i],
-        varY_list[i],
-        N_list[i]
+        beta_hat_list[i], se_list[i], R_list_copy[i], varY_list[i], N_list[i]
     )
     XTX_list.append(R_list_copy[i])
     XTY_list.append(XTY)
@@ -117,25 +151,22 @@ for i in range(len(R_list)):
 X_l2_arr = np.array([np.diag(XTX) for XTX in XTX_list])
 for i in range(len(XTX_list)):
     MultiSuSiE.recover_R_from_XTX(XTX_list[i], X_l2_arr[i])
-assert(all([np.nanmax(np.abs(R - XTX)) < 1e-10 for (R, XTX) in zip(R_list, XTX_list)]))
+assert all([np.nanmax(np.abs(R - XTX)) < 1e-10 for (R, XTX) in zip(R_list, XTX_list)])
 
 
 # TEST 4: test that recover_XTX_and_XTY_from_Z recovers XTX and XTY with standardized genotypes and phenotypes
-z_list = [b/s for (b,s) in zip(beta_hat_list, se_list)]
-with np.errstate(divide='ignore',invalid='ignore'):
-    geno_std_list = [geno / np.std(geno, axis = 0, ddof = 1) for geno in geno_list]
-y_std_list = [y / np.std(y, ddof = 1) for y in y_list]
+z_list = [b / s for (b, s) in zip(beta_hat_list, se_list)]
+with np.errstate(divide="ignore", invalid="ignore"):
+    geno_std_list = [geno / np.std(geno, axis=0, ddof=1) for geno in geno_list]
+y_std_list = [y / np.std(y, ddof=1) for y in y_list]
 XTX_std_list = [geno.T.dot(geno) for geno in geno_std_list]
 XTY_std_list = [geno.T.dot(pheno) for (geno, pheno) in zip(geno_std_list, y_std_list)]
 
 for i in range(len(z_list)):
     XTX, XTY = MultiSuSiE.recover_XTX_and_XTY_from_Z(
-        z = z_list[i], 
-        R = np.copy(R_list[i]),
-        n = N_list[i],
-        float_type = np.float64
+        z=z_list[i], R=np.copy(R_list[i]), n=N_list[i], float_type=np.float64
     )
-    assert(np.nanmax(np.abs(np.nan_to_num(XTX, 0) - XTX_std_list[i])) < 1e-10)
-    assert(np.nanmax(np.abs(np.nan_to_num(XTY, 0) - XTY_std_list[i])) < 1e-10)
+    assert np.nanmax(np.abs(np.nan_to_num(XTX, 0) - XTX_std_list[i])) < 1e-10
+    assert np.nanmax(np.abs(np.nan_to_num(XTY, 0) - XTY_std_list[i])) < 1e-10
 
-print('No tests failed!')
+print("No tests failed!")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 
-
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 SRC_PATH = os.path.join(REPO_ROOT, "src")
 
@@ -54,18 +53,29 @@ def synthetic_data() -> SyntheticData:
     beta_list = [beta_yri, beta_ceu, beta_jpt]
 
     rng = np.random.default_rng(1)
-    y_list = [geno.dot(beta) + rng.standard_normal(geno.shape[0]) for geno, beta in zip(geno_list, beta_list)]
+    y_list = [
+        geno.dot(beta) + rng.standard_normal(geno.shape[0])
+        for geno, beta in zip(geno_list, beta_list)
+    ]
     y_list = [y - np.mean(y) for y in y_list]
 
     xty_list = [geno.T.dot(y) for geno, y in zip(geno_list, y_list)]
     xtx_diag_list = [np.diagonal(geno.T.dot(geno)) for geno in geno_list]
     with np.errstate(divide="ignore", invalid="ignore"):
-        beta_hat_list = [xty / xtx_diag for xty, xtx_diag in zip(xty_list, xtx_diag_list)]
+        beta_hat_list = [
+            xty / xtx_diag for xty, xtx_diag in zip(xty_list, xtx_diag_list)
+        ]
 
     n_list = [geno.shape[0] for geno in geno_list]
-    residuals_list = [np.expand_dims(y, 1) - (geno * beta) for y, geno, beta in zip(y_list, geno_list, beta_hat_list)]
-    ssr_list = [np.sum(resid ** 2, axis=0) for resid in residuals_list]
-    se_list = [np.sqrt(ssr / ((n - 2) * xtx)) for ssr, n, xtx in zip(ssr_list, n_list, xtx_diag_list)]
+    residuals_list = [
+        np.expand_dims(y, 1) - (geno * beta)
+        for y, geno, beta in zip(y_list, geno_list, beta_hat_list)
+    ]
+    ssr_list = [np.sum(resid**2, axis=0) for resid in residuals_list]
+    se_list = [
+        np.sqrt(ssr / ((n - 2) * xtx))
+        for ssr, n, xtx in zip(ssr_list, n_list, xtx_diag_list)
+    ]
 
     with np.errstate(divide="ignore", invalid="ignore"):
         r_list = [np.corrcoef(geno, rowvar=False) for geno in geno_list]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import random
 import sys
 from dataclasses import dataclass
 
@@ -11,6 +12,12 @@ SRC_PATH = os.path.join(REPO_ROOT, "src")
 
 if SRC_PATH not in sys.path:
     sys.path.insert(0, SRC_PATH)
+
+
+@pytest.fixture(autouse=True)
+def fixed_test_seeds():
+    random.seed(0)
+    np.random.seed(0)
 
 
 @dataclass

--- a/tests/test_bayes_factor_math.py
+++ b/tests/test_bayes_factor_math.py
@@ -46,7 +46,9 @@ def _design_for_variant(x_list, variant_idx):
     return z
 
 
-def _direct_multi_pop_log_bf_for_variant(x_list, y_list, residual_variance, rho, prior_variance, variant_idx):
+def _direct_multi_pop_log_bf_for_variant(
+    x_list, y_list, residual_variance, rho, prior_variance, variant_idx
+):
     y = np.concatenate(y_list)
     n_total = y.shape[0]
 
@@ -67,7 +69,9 @@ def _direct_multi_pop_log_bf_for_variant(x_list, y_list, residual_variance, rho,
     return loglik1 - loglik0
 
 
-def _direct_multi_pop_posterior_for_variant(x_list, y_list, residual_variance, rho, prior_variance, variant_idx):
+def _direct_multi_pop_posterior_for_variant(
+    x_list, y_list, residual_variance, rho, prior_variance, variant_idx
+):
     y = np.concatenate(y_list)
     z = _design_for_variant(x_list, variant_idx)
     a = rho * np.sqrt(np.outer(prior_variance, prior_variance))
@@ -82,7 +86,9 @@ def _direct_multi_pop_posterior_for_variant(x_list, y_list, residual_variance, r
 
 
 @pytest.mark.parametrize("prior_var", [1e-6, 0.05, 0.2, 1.0])
-def test_single_population_compute_lbf_matches_direct_bayesian_linear_regression(prior_var):
+def test_single_population_compute_lbf_matches_direct_bayesian_linear_regression(
+    prior_var,
+):
     rng = np.random.default_rng(2026)
     n = 30
     p = 7
@@ -118,7 +124,10 @@ def test_single_population_compute_lbf_matches_direct_bayesian_linear_regression
     )
 
     lbf_direct = np.array(
-        [_direct_log_bf_single_predictor(x[:, j], y, sigma2, prior_var) for j in range(p)],
+        [
+            _direct_log_bf_single_predictor(x[:, j], y, sigma2, prior_var)
+            for j in range(p)
+        ],
         dtype=float,
     )
 
@@ -248,7 +257,9 @@ def test_single_population_posterior_moments_match_direct_gaussian_conditioning(
     direct_second = np.array(direct_second, dtype=float)
     np.testing.assert_allclose(post_mean_indiv[0], direct_means, rtol=0, atol=1e-10)
     np.testing.assert_allclose(post_mean_ss[0], direct_means, rtol=0, atol=1e-10)
-    np.testing.assert_allclose(post_mean2_indiv[0, 0], direct_second, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(
+        post_mean2_indiv[0, 0], direct_second, rtol=0, atol=1e-10
+    )
     np.testing.assert_allclose(post_mean2_ss[0, 0], direct_second, rtol=0, atol=1e-10)
 
 
@@ -298,5 +309,9 @@ def test_multipopulation_posterior_moments_match_direct_gaussian_conditioning():
         )
         np.testing.assert_allclose(post_mean_indiv[:, j], m_direct, rtol=0, atol=1e-10)
         np.testing.assert_allclose(post_mean_ss[:, j], m_direct, rtol=0, atol=1e-10)
-        np.testing.assert_allclose(post_mean2_indiv[:, :, j], s2_direct, rtol=0, atol=1e-10)
-        np.testing.assert_allclose(post_mean2_ss[:, :, j], s2_direct, rtol=0, atol=1e-10)
+        np.testing.assert_allclose(
+            post_mean2_indiv[:, :, j], s2_direct, rtol=0, atol=1e-10
+        )
+        np.testing.assert_allclose(
+            post_mean2_ss[:, :, j], s2_direct, rtol=0, atol=1e-10
+        )

--- a/tests/test_bayes_factor_math.py
+++ b/tests/test_bayes_factor_math.py
@@ -1,0 +1,302 @@
+import numpy as np
+import pytest
+
+from MultiSuSiE import susiepy
+from MultiSuSiE import susiepy_ss
+
+
+def _direct_log_bf_single_predictor(x, y, sigma2, prior_var):
+    n = y.shape[0]
+    eye = np.eye(n)
+
+    sigma0 = sigma2 * eye
+    sigma1 = sigma2 * eye + prior_var * np.outer(x, x)
+
+    sign0, logdet0 = np.linalg.slogdet(sigma0)
+    sign1, logdet1 = np.linalg.slogdet(sigma1)
+    assert sign0 > 0 and sign1 > 0
+
+    quad0 = y.dot(np.linalg.solve(sigma0, y))
+    quad1 = y.dot(np.linalg.solve(sigma1, y))
+
+    loglik0 = -0.5 * (n * np.log(2 * np.pi) + logdet0 + quad0)
+    loglik1 = -0.5 * (n * np.log(2 * np.pi) + logdet1 + quad1)
+    return loglik1 - loglik0
+
+
+def _stacked_sigma0(residual_variance, n_list):
+    total_n = int(np.sum(n_list))
+    sigma0 = np.zeros((total_n, total_n), dtype=float)
+    start = 0
+    for s2, n in zip(residual_variance, n_list):
+        sigma0[start : start + n, start : start + n] = s2 * np.eye(n)
+        start += n
+    return sigma0
+
+
+def _design_for_variant(x_list, variant_idx):
+    total_n = int(np.sum([x.shape[0] for x in x_list]))
+    k = len(x_list)
+    z = np.zeros((total_n, k), dtype=float)
+    start = 0
+    for pop_idx, x in enumerate(x_list):
+        n = x.shape[0]
+        z[start : start + n, pop_idx] = x[:, variant_idx]
+        start += n
+    return z
+
+
+def _direct_multi_pop_log_bf_for_variant(x_list, y_list, residual_variance, rho, prior_variance, variant_idx):
+    y = np.concatenate(y_list)
+    n_total = y.shape[0]
+
+    sigma0 = _stacked_sigma0(residual_variance, [x.shape[0] for x in x_list])
+    z = _design_for_variant(x_list, variant_idx)
+    a = rho * np.sqrt(np.outer(prior_variance, prior_variance))
+    sigma1 = sigma0 + z.dot(a).dot(z.T)
+
+    sign0, logdet0 = np.linalg.slogdet(sigma0)
+    sign1, logdet1 = np.linalg.slogdet(sigma1)
+    assert sign0 > 0 and sign1 > 0
+
+    quad0 = y.dot(np.linalg.solve(sigma0, y))
+    quad1 = y.dot(np.linalg.solve(sigma1, y))
+
+    loglik0 = -0.5 * (n_total * np.log(2 * np.pi) + logdet0 + quad0)
+    loglik1 = -0.5 * (n_total * np.log(2 * np.pi) + logdet1 + quad1)
+    return loglik1 - loglik0
+
+
+def _direct_multi_pop_posterior_for_variant(x_list, y_list, residual_variance, rho, prior_variance, variant_idx):
+    y = np.concatenate(y_list)
+    z = _design_for_variant(x_list, variant_idx)
+    a = rho * np.sqrt(np.outer(prior_variance, prior_variance))
+    sigma0 = _stacked_sigma0(residual_variance, [x.shape[0] for x in x_list])
+    sigma_y = sigma0 + z.dot(a).dot(z.T)
+    cov_by = a.dot(z.T)
+    inv_sigma_y_y = np.linalg.solve(sigma_y, y)
+    post_mean = cov_by.dot(inv_sigma_y_y)
+    post_covar = a - cov_by.dot(np.linalg.solve(sigma_y, cov_by.T))
+    post_second = post_covar + np.outer(post_mean, post_mean)
+    return post_mean, post_second
+
+
+@pytest.mark.parametrize("prior_var", [1e-6, 0.05, 0.2, 1.0])
+def test_single_population_compute_lbf_matches_direct_bayesian_linear_regression(prior_var):
+    rng = np.random.default_rng(2026)
+    n = 30
+    p = 7
+    sigma2 = 1.3
+
+    x = rng.normal(size=(n, p))
+    x[:, 0] = 0.0
+    y = rng.normal(size=n)
+
+    xty = x.T.dot(y)
+    xtx = x.T.dot(x)
+    x_l2 = np.array([np.diag(xtx)], dtype=np.float64)
+
+    x_l2_vec = np.einsum("ij,ij->j", x, x)
+    lbf_individual = susiepy.compute_lbf_1pop(
+        V=prior_var,
+        X_std=x,
+        Y=y,
+        X_l2=x_l2_vec,
+        residual_variance=sigma2,
+        return_moments=False,
+        float_type=np.float64,
+    )
+    lbf_summary = susiepy_ss.compute_lbf(
+        V=np.array([prior_var], dtype=np.float64),
+        XTY_list=[xty.astype(np.float64)],
+        XTX_list=[xtx.astype(np.float64)],
+        X_l2_arr=x_l2,
+        rho=np.array([[1.0]], dtype=np.float64),
+        residual_variance=np.array([sigma2], dtype=np.float64),
+        return_moments=False,
+        float_type=np.float64,
+    )
+
+    lbf_direct = np.array(
+        [_direct_log_bf_single_predictor(x[:, j], y, sigma2, prior_var) for j in range(p)],
+        dtype=float,
+    )
+
+    np.testing.assert_allclose(lbf_individual, lbf_direct, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(lbf_summary, lbf_direct, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(lbf_individual, lbf_summary, rtol=0, atol=1e-12)
+    assert np.isclose(lbf_direct[0], 0.0)
+
+
+@pytest.mark.parametrize(
+    "prior_variance",
+    [
+        np.array([0.25, 0.15], dtype=np.float64),
+        np.array([0.0, 0.15], dtype=np.float64),
+    ],
+)
+def test_multipop_compute_lbf_matches_direct_bayesian_linear_regression(prior_variance):
+    rng = np.random.default_rng(2028)
+    n_list = [14, 11]
+    p = 5
+    residual_variance = np.array([1.1, 0.9], dtype=np.float64)
+    rho = np.array([[1.0, 0.55], [0.55, 1.0]], dtype=np.float64)
+
+    x_list = [rng.normal(size=(n, p)) for n in n_list]
+    x_list[0][:, 0] = 0.0
+    x_list[1][:, 0] = 0.0
+    y_list = [rng.normal(size=n) for n in n_list]
+
+    x_l2_arr = np.array([np.einsum("ij,ij->j", x, x) for x in x_list], dtype=np.float64)
+    xty_list = [x.T.dot(y) for x, y in zip(x_list, y_list)]
+    xtx_list = [x.T.dot(x) for x in x_list]
+
+    lbf_individual = susiepy.compute_lbf(
+        V=prior_variance,
+        Y_list=y_list,
+        X_std_list=x_list,
+        X_l2_arr=x_l2_arr,
+        rho=rho,
+        residual_variance=residual_variance,
+        return_moments=False,
+        float_type=np.float64,
+    )
+    lbf_summary = susiepy_ss.compute_lbf(
+        V=prior_variance,
+        XTY_list=xty_list,
+        XTX_list=xtx_list,
+        X_l2_arr=x_l2_arr,
+        rho=rho,
+        residual_variance=residual_variance,
+        return_moments=False,
+        float_type=np.float64,
+    )
+    lbf_direct = np.array(
+        [
+            _direct_multi_pop_log_bf_for_variant(
+                x_list=x_list,
+                y_list=y_list,
+                residual_variance=residual_variance,
+                rho=rho,
+                prior_variance=prior_variance,
+                variant_idx=j,
+            )
+            for j in range(p)
+        ],
+        dtype=float,
+    )
+
+    np.testing.assert_allclose(lbf_individual, lbf_direct, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(lbf_summary, lbf_direct, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(lbf_individual, lbf_summary, rtol=0, atol=1e-12)
+    assert np.isclose(lbf_direct[0], 0.0)
+
+
+def test_single_population_posterior_moments_match_direct_gaussian_conditioning():
+    rng = np.random.default_rng(2029)
+    n = 26
+    p = 6
+    sigma2 = np.array([1.4], dtype=np.float64)
+    prior_variance = np.array([0.2], dtype=np.float64)
+    rho = np.array([[1.0]], dtype=np.float64)
+
+    x = rng.normal(size=(n, p))
+    y = rng.normal(size=n)
+
+    x_list = [x]
+    y_list = [y]
+    x_l2_arr = np.array([np.einsum("ij,ij->j", x, x)], dtype=np.float64)
+    xty_list = [x.T.dot(y)]
+    xtx_list = [x.T.dot(x)]
+
+    _, post_mean_indiv, post_mean2_indiv = susiepy.compute_lbf(
+        V=prior_variance,
+        Y_list=y_list,
+        X_std_list=x_list,
+        X_l2_arr=x_l2_arr,
+        rho=rho,
+        residual_variance=sigma2,
+        return_moments=True,
+        float_type=np.float64,
+    )
+    _, post_mean_ss, post_mean2_ss = susiepy_ss.compute_lbf(
+        V=prior_variance,
+        XTY_list=xty_list,
+        XTX_list=xtx_list,
+        X_l2_arr=x_l2_arr,
+        rho=rho,
+        residual_variance=sigma2,
+        return_moments=True,
+        float_type=np.float64,
+    )
+
+    direct_means = []
+    direct_second = []
+    for j in range(p):
+        m, s2 = _direct_multi_pop_posterior_for_variant(
+            x_list=x_list,
+            y_list=y_list,
+            residual_variance=sigma2,
+            rho=rho,
+            prior_variance=prior_variance,
+            variant_idx=j,
+        )
+        direct_means.append(m[0])
+        direct_second.append(s2[0, 0])
+
+    direct_means = np.array(direct_means, dtype=float)
+    direct_second = np.array(direct_second, dtype=float)
+    np.testing.assert_allclose(post_mean_indiv[0], direct_means, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(post_mean_ss[0], direct_means, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(post_mean2_indiv[0, 0], direct_second, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(post_mean2_ss[0, 0], direct_second, rtol=0, atol=1e-10)
+
+
+def test_multipopulation_posterior_moments_match_direct_gaussian_conditioning():
+    rng = np.random.default_rng(2030)
+    n_list = [13, 11]
+    p = 5
+    residual_variance = np.array([1.2, 0.8], dtype=np.float64)
+    prior_variance = np.array([0.25, 0.15], dtype=np.float64)
+    rho = np.array([[1.0, 0.5], [0.5, 1.0]], dtype=np.float64)
+
+    x_list = [rng.normal(size=(n, p)) for n in n_list]
+    y_list = [rng.normal(size=n) for n in n_list]
+    x_l2_arr = np.array([np.einsum("ij,ij->j", x, x) for x in x_list], dtype=np.float64)
+    xty_list = [x.T.dot(y) for x, y in zip(x_list, y_list)]
+    xtx_list = [x.T.dot(x) for x in x_list]
+
+    _, post_mean_indiv, post_mean2_indiv = susiepy.compute_lbf(
+        V=prior_variance,
+        Y_list=y_list,
+        X_std_list=x_list,
+        X_l2_arr=x_l2_arr,
+        rho=rho,
+        residual_variance=residual_variance,
+        return_moments=True,
+        float_type=np.float64,
+    )
+    _, post_mean_ss, post_mean2_ss = susiepy_ss.compute_lbf(
+        V=prior_variance,
+        XTY_list=xty_list,
+        XTX_list=xtx_list,
+        X_l2_arr=x_l2_arr,
+        rho=rho,
+        residual_variance=residual_variance,
+        return_moments=True,
+        float_type=np.float64,
+    )
+
+    for j in range(p):
+        m_direct, s2_direct = _direct_multi_pop_posterior_for_variant(
+            x_list=x_list,
+            y_list=y_list,
+            residual_variance=residual_variance,
+            rho=rho,
+            prior_variance=prior_variance,
+            variant_idx=j,
+        )
+        np.testing.assert_allclose(post_mean_indiv[:, j], m_direct, rtol=0, atol=1e-10)
+        np.testing.assert_allclose(post_mean_ss[:, j], m_direct, rtol=0, atol=1e-10)
+        np.testing.assert_allclose(post_mean2_indiv[:, :, j], s2_direct, rtol=0, atol=1e-10)
+        np.testing.assert_allclose(post_mean2_ss[:, :, j], s2_direct, rtol=0, atol=1e-10)

--- a/tests/test_convergence_elbo.py
+++ b/tests/test_convergence_elbo.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+import MultiSuSiE
+
+
+@pytest.mark.parametrize("method", ["individual", "rss"])
+def test_elbo_is_monotone_in_restricted_coordinate_ascent_regime(synthetic_data, method):
+    kwargs = dict(synthetic_data.common)
+    kwargs.update(
+        estimate_residual_variance=False,
+        estimate_prior_variance=False,
+        estimate_prior_method=None,
+        iter_before_zeroing_effects=999,
+        max_iter=40,
+        tol=1e-12,
+        min_abs_corr=0,
+    )
+
+    if method == "individual":
+        fit = MultiSuSiE.multisusie(
+            X_list=[x.copy() for x in synthetic_data.geno_list],
+            Y_list=[y.copy() for y in synthetic_data.y_list],
+            standardize=False,
+            **kwargs,
+        )
+    else:
+        fit = MultiSuSiE.multisusie_rss(
+            b_list=[b.copy() for b in synthetic_data.beta_hat_list],
+            s_list=[s.copy() for s in synthetic_data.se_list],
+            R_list=[r.copy() for r in synthetic_data.r_list],
+            varY_list=synthetic_data.vary_list,
+            population_sizes=synthetic_data.n_list,
+            single_population_mac_thresh=0,
+            low_memory_mode=False,
+            recover_R=False,
+            **kwargs,
+        )
+
+    assert len(fit.elbo) == fit.niter
+    assert np.all(np.isfinite(fit.elbo))
+    delta = np.diff(fit.elbo)
+    assert np.all(delta >= -1e-12)
+    if method == "rss":
+        assert fit.niter == kwargs["max_iter"]
+        assert fit.converged is False
+    else:
+        assert fit.niter < kwargs["max_iter"]
+        assert fit.converged is True

--- a/tests/test_convergence_elbo.py
+++ b/tests/test_convergence_elbo.py
@@ -5,7 +5,9 @@ import MultiSuSiE
 
 
 @pytest.mark.parametrize("method", ["individual", "rss"])
-def test_elbo_is_monotone_in_restricted_coordinate_ascent_regime(synthetic_data, method):
+def test_elbo_is_monotone_in_restricted_coordinate_ascent_regime(
+    synthetic_data, method
+):
     kwargs = dict(synthetic_data.common)
     kwargs.update(
         estimate_residual_variance=False,
@@ -33,7 +35,6 @@ def test_elbo_is_monotone_in_restricted_coordinate_ascent_regime(synthetic_data,
             population_sizes=synthetic_data.n_list,
             single_population_mac_thresh=0,
             low_memory_mode=False,
-            recover_R=False,
             **kwargs,
         )
 

--- a/tests/test_credible_sets_purity.py
+++ b/tests/test_credible_sets_purity.py
@@ -56,15 +56,17 @@ def _make_reasonable_filtering_case(seed=4):
     with np.errstate(divide="ignore", invalid="ignore"):
         b_list = [xy / xd for xy, xd in zip(xty, xtx_diag)]
     n_list = [n1, n2]
-    residuals = [np.expand_dims(y, 1) - (x * b) for x, y, b in zip(x_list, y_list, b_list)]
-    ssr = [np.sum(r ** 2, axis=0) for r in residuals]
+    residuals = [
+        np.expand_dims(y, 1) - (x * b) for x, y, b in zip(x_list, y_list, b_list)
+    ]
+    ssr = [np.sum(r**2, axis=0) for r in residuals]
     s_list = [np.sqrt(s / ((n - 2) * xd)) for s, n, xd in zip(ssr, n_list, xtx_diag)]
     r_list = [np.corrcoef(x, rowvar=False) for x in x_list]
     vary_list = [np.var(y, ddof=1) for y in y_list]
     return x_list, y_list, b_list, s_list, r_list, vary_list, n_list, common
 
 
-def test_rss_low_memory_without_recover_r_skips_purity(synthetic_data):
+def test_rss_low_memory_with_zero_min_abs_corr_skips_purity(synthetic_data):
     kwargs = dict(synthetic_data.common)
     kwargs["min_abs_corr"] = 0
     fit = MultiSuSiE.multisusie_rss(
@@ -74,7 +76,6 @@ def test_rss_low_memory_without_recover_r_skips_purity(synthetic_data):
         varY_list=synthetic_data.vary_list,
         population_sizes=synthetic_data.n_list,
         low_memory_mode=True,
-        recover_R=False,
         single_population_mac_thresh=0,
         **kwargs,
     )
@@ -82,9 +83,9 @@ def test_rss_low_memory_without_recover_r_skips_purity(synthetic_data):
     assert np.all(np.isnan(purity))
 
 
-def test_rss_low_memory_with_recover_r_computes_purity(synthetic_data):
+def test_rss_low_memory_with_positive_min_abs_corr_computes_purity(synthetic_data):
     kwargs = dict(synthetic_data.common)
-    kwargs["min_abs_corr"] = 0
+    kwargs["min_abs_corr"] = 0.1
     fit = MultiSuSiE.multisusie_rss(
         b_list=[b.copy() for b in synthetic_data.beta_hat_list],
         s_list=[s.copy() for s in synthetic_data.se_list],
@@ -92,7 +93,6 @@ def test_rss_low_memory_with_recover_r_computes_purity(synthetic_data):
         varY_list=synthetic_data.vary_list,
         population_sizes=synthetic_data.n_list,
         low_memory_mode=True,
-        recover_R=True,
         single_population_mac_thresh=0,
         **kwargs,
     )
@@ -125,8 +125,12 @@ def test_individual_calculate_purity_flag_controls_purity_output(synthetic_data)
 def test_get_purity_x_respects_n_purity():
     cs = np.array([0, 1, 2], dtype=int)
     r = np.eye(3)
-    purity_all = susiepy_ss.get_purity_x(cs=cs, R_list=[r], min_abs_cor=0, n_purity=3, X_list=None)
-    purity_subsampled = susiepy_ss.get_purity_x(cs=cs, R_list=[r], min_abs_cor=0, n_purity=1, X_list=None)
+    purity_all = susiepy_ss.get_purity_x(
+        cs=cs, R_list=[r], min_abs_cor=0, n_purity=3, X_list=None
+    )
+    purity_subsampled = susiepy_ss.get_purity_x(
+        cs=cs, R_list=[r], min_abs_cor=0, n_purity=1, X_list=None
+    )
     assert np.isclose(purity_all, 0.0)
     assert np.isclose(purity_subsampled, 1.0)
 
@@ -183,7 +187,6 @@ def test_end_to_end_purity_values_match_direct_recomputation(synthetic_data, met
             population_sizes=synthetic_data.n_list,
             single_population_mac_thresh=0,
             low_memory_mode=False,
-            recover_R=False,
             **kwargs,
         )
     else:
@@ -222,7 +225,6 @@ def test_end_to_end_purity_filtering_matches_threshold(synthetic_data, method):
             population_sizes=synthetic_data.n_list,
             single_population_mac_thresh=0,
             low_memory_mode=False,
-            recover_R=False,
             **kwargs,
         )
     else:
@@ -246,7 +248,9 @@ def test_end_to_end_purity_filtering_matches_threshold(synthetic_data, method):
 
 @pytest.mark.parametrize("method", ["rss", "individual"])
 def test_end_to_end_purity_filtering_activates_for_reasonable_threshold(method):
-    x_list, y_list, b_list, s_list, r_list, vary_list, n_list, common = _make_reasonable_filtering_case()
+    x_list, y_list, b_list, s_list, r_list, vary_list, n_list, common = (
+        _make_reasonable_filtering_case()
+    )
 
     if method == "rss":
         baseline = MultiSuSiE.multisusie_rss(
@@ -257,7 +261,6 @@ def test_end_to_end_purity_filtering_activates_for_reasonable_threshold(method):
             population_sizes=n_list,
             single_population_mac_thresh=0,
             low_memory_mode=False,
-            recover_R=False,
             min_abs_corr=0,
             **common,
         )
@@ -290,7 +293,6 @@ def test_end_to_end_purity_filtering_activates_for_reasonable_threshold(method):
             population_sizes=n_list,
             single_population_mac_thresh=0,
             low_memory_mode=False,
-            recover_R=False,
             min_abs_corr=threshold,
             **common,
         )

--- a/tests/test_credible_sets_purity.py
+++ b/tests/test_credible_sets_purity.py
@@ -1,0 +1,312 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import MultiSuSiE
+import MultiSuSiE.susiepy_ss as susiepy_ss
+
+
+def _expected_purity_for_cs(cs, r_list):
+    if len(cs) == 0:
+        return np.nan
+    r_sub = [r[np.ix_(cs, cs)] for r in r_list]
+    abs_meta_r = np.maximum.reduce([np.abs(r) for r in r_sub])
+    return float(np.min(abs_meta_r))
+
+
+def _make_reasonable_filtering_case(seed=4):
+    rng = np.random.default_rng(seed)
+    p = 6
+    n1, n2 = 120, 110
+    cov = np.array(
+        [
+            [1, 0.4, 0.2, 0, 0, 0],
+            [0.4, 1, 0.3, 0, 0, 0],
+            [0.2, 0.3, 1, 0, 0, 0],
+            [0, 0, 0, 1, 0.5, 0.1],
+            [0, 0, 0, 0.5, 1, 0.2],
+            [0, 0, 0, 0.1, 0.2, 1],
+        ],
+        dtype=float,
+    )
+    chol = np.linalg.cholesky(cov)
+    x1 = rng.normal(size=(n1, p)).dot(chol.T)
+    x2 = rng.normal(size=(n2, p)).dot(chol.T)
+    beta = np.array([0.15, 0.14, 0.0, 0.0, 0.0, 0.0], dtype=float)
+    y1 = x1.dot(beta) + rng.normal(scale=1.2, size=n1)
+    y2 = x2.dot(beta) + rng.normal(scale=1.2, size=n2)
+    y1 -= y1.mean()
+    y2 -= y2.mean()
+    x_list = [x1, x2]
+    y_list = [y1, y2]
+    rho = np.array([[1, 0.8], [0.8, 1]], dtype=float)
+    common = dict(
+        rho=rho,
+        L=4,
+        scaled_prior_variance=0.2,
+        estimate_prior_method="EM",
+        pop_spec_effect_priors=False,
+        iter_before_zeroing_effects=0,
+        float_type=np.float64,
+    )
+
+    xty = [x.T.dot(y) for x, y in zip(x_list, y_list)]
+    xtx_diag = [np.diag(x.T.dot(x)) for x in x_list]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        b_list = [xy / xd for xy, xd in zip(xty, xtx_diag)]
+    n_list = [n1, n2]
+    residuals = [np.expand_dims(y, 1) - (x * b) for x, y, b in zip(x_list, y_list, b_list)]
+    ssr = [np.sum(r ** 2, axis=0) for r in residuals]
+    s_list = [np.sqrt(s / ((n - 2) * xd)) for s, n, xd in zip(ssr, n_list, xtx_diag)]
+    r_list = [np.corrcoef(x, rowvar=False) for x in x_list]
+    vary_list = [np.var(y, ddof=1) for y in y_list]
+    return x_list, y_list, b_list, s_list, r_list, vary_list, n_list, common
+
+
+def test_rss_low_memory_without_recover_r_skips_purity(synthetic_data):
+    kwargs = dict(synthetic_data.common)
+    kwargs["min_abs_corr"] = 0
+    fit = MultiSuSiE.multisusie_rss(
+        b_list=[b.copy() for b in synthetic_data.beta_hat_list],
+        s_list=[s.copy() for s in synthetic_data.se_list],
+        R_list=[r.copy() for r in synthetic_data.r_list],
+        varY_list=synthetic_data.vary_list,
+        population_sizes=synthetic_data.n_list,
+        low_memory_mode=True,
+        recover_R=False,
+        single_population_mac_thresh=0,
+        **kwargs,
+    )
+    purity = np.asarray(fit.sets[1], dtype=float)
+    assert np.all(np.isnan(purity))
+
+
+def test_rss_low_memory_with_recover_r_computes_purity(synthetic_data):
+    kwargs = dict(synthetic_data.common)
+    kwargs["min_abs_corr"] = 0
+    fit = MultiSuSiE.multisusie_rss(
+        b_list=[b.copy() for b in synthetic_data.beta_hat_list],
+        s_list=[s.copy() for s in synthetic_data.se_list],
+        R_list=[r.copy() for r in synthetic_data.r_list],
+        varY_list=synthetic_data.vary_list,
+        population_sizes=synthetic_data.n_list,
+        low_memory_mode=True,
+        recover_R=True,
+        single_population_mac_thresh=0,
+        **kwargs,
+    )
+    purity = np.asarray(fit.sets[1], dtype=float)
+    assert np.any(np.isfinite(purity))
+
+
+def test_individual_calculate_purity_flag_controls_purity_output(synthetic_data):
+    fit_no_purity = MultiSuSiE.multisusie(
+        X_list=[x.copy() for x in synthetic_data.geno_list],
+        Y_list=[y.copy() for y in synthetic_data.y_list],
+        standardize=False,
+        calculate_purity=False,
+        **synthetic_data.common,
+    )
+    purity_no = np.asarray(fit_no_purity.sets[1], dtype=float)
+    assert np.all(np.isnan(purity_no))
+
+    fit_purity = MultiSuSiE.multisusie(
+        X_list=[x.copy() for x in synthetic_data.geno_list],
+        Y_list=[y.copy() for y in synthetic_data.y_list],
+        standardize=False,
+        calculate_purity=True,
+        **synthetic_data.common,
+    )
+    purity_yes = np.asarray(fit_purity.sets[1], dtype=float)
+    assert np.any(np.isfinite(purity_yes))
+
+
+def test_get_purity_x_respects_n_purity():
+    cs = np.array([0, 1, 2], dtype=int)
+    r = np.eye(3)
+    purity_all = susiepy_ss.get_purity_x(cs=cs, R_list=[r], min_abs_cor=0, n_purity=3, X_list=None)
+    purity_subsampled = susiepy_ss.get_purity_x(cs=cs, R_list=[r], min_abs_cor=0, n_purity=1, X_list=None)
+    assert np.isclose(purity_all, 0.0)
+    assert np.isclose(purity_subsampled, 1.0)
+
+
+def test_susie_get_cs_filters_by_min_abs_corr_only_when_calculating_purity():
+    s = SimpleNamespace(
+        alpha=np.array([[0.6, 0.4, 0.0]], dtype=float),
+        V=np.array([[0.1]], dtype=float),
+    )
+    r = np.array(
+        [
+            [1.0, 0.1, 0.0],
+            [0.1, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+
+    cs_with_purity = susiepy_ss.susie_get_cs(
+        s=s,
+        R_list=[r],
+        coverage=0.95,
+        min_abs_corr=0.5,
+        dedup=True,
+        n_purity=100,
+        calculate_purity=True,
+        X_list=None,
+    )
+    assert bool(cs_with_purity[3][0]) is False
+
+    cs_without_purity = susiepy_ss.susie_get_cs(
+        s=s,
+        R_list=[r],
+        coverage=0.95,
+        min_abs_corr=0.5,
+        dedup=True,
+        n_purity=100,
+        calculate_purity=False,
+        X_list=None,
+    )
+    assert bool(cs_without_purity[3][0]) is True
+
+
+@pytest.mark.parametrize("method", ["rss", "individual"])
+def test_end_to_end_purity_values_match_direct_recomputation(synthetic_data, method):
+    kwargs = dict(synthetic_data.common)
+    kwargs["min_abs_corr"] = 0
+    if method == "rss":
+        fit = MultiSuSiE.multisusie_rss(
+            b_list=[b.copy() for b in synthetic_data.beta_hat_list],
+            s_list=[s.copy() for s in synthetic_data.se_list],
+            R_list=[r.copy() for r in synthetic_data.r_list],
+            varY_list=synthetic_data.vary_list,
+            population_sizes=synthetic_data.n_list,
+            single_population_mac_thresh=0,
+            low_memory_mode=False,
+            recover_R=False,
+            **kwargs,
+        )
+    else:
+        fit = MultiSuSiE.multisusie(
+            X_list=[x.copy() for x in synthetic_data.geno_list],
+            Y_list=[y.copy() for y in synthetic_data.y_list],
+            standardize=False,
+            calculate_purity=True,
+            n_purity=10_000,
+            **kwargs,
+        )
+
+    cs_list, purity_list, _, include_mask = fit.sets
+    for cs, purity, include in zip(cs_list, purity_list, include_mask):
+        if include:
+            expected = _expected_purity_for_cs(cs, synthetic_data.r_list)
+            if np.isnan(expected):
+                assert np.isnan(purity)
+            else:
+                assert np.isclose(float(purity), expected, atol=1e-10)
+
+
+@pytest.mark.parametrize("method", ["rss", "individual"])
+def test_end_to_end_purity_filtering_matches_threshold(synthetic_data, method):
+    # Use a threshold above the maximum attainable purity (1.0) so the test
+    # deterministically exercises purity-based filtering.
+    threshold = 1.01
+    kwargs = dict(synthetic_data.common)
+    kwargs["min_abs_corr"] = threshold
+    if method == "rss":
+        fit = MultiSuSiE.multisusie_rss(
+            b_list=[b.copy() for b in synthetic_data.beta_hat_list],
+            s_list=[s.copy() for s in synthetic_data.se_list],
+            R_list=[r.copy() for r in synthetic_data.r_list],
+            varY_list=synthetic_data.vary_list,
+            population_sizes=synthetic_data.n_list,
+            single_population_mac_thresh=0,
+            low_memory_mode=False,
+            recover_R=False,
+            **kwargs,
+        )
+    else:
+        fit = MultiSuSiE.multisusie(
+            X_list=[x.copy() for x in synthetic_data.geno_list],
+            Y_list=[y.copy() for y in synthetic_data.y_list],
+            standardize=False,
+            calculate_purity=True,
+            n_purity=10_000,
+            **kwargs,
+        )
+
+    _, purity_list, _, include_mask = fit.sets
+    purity_arr = np.asarray(purity_list, dtype=float)
+    include_arr = np.asarray(include_mask, dtype=bool)
+    finite = np.isfinite(purity_arr)
+    assert np.any(finite)
+    assert np.any((~include_arr) & finite)
+    assert np.all(include_arr[finite] == (purity_arr[finite] >= threshold))
+
+
+@pytest.mark.parametrize("method", ["rss", "individual"])
+def test_end_to_end_purity_filtering_activates_for_reasonable_threshold(method):
+    x_list, y_list, b_list, s_list, r_list, vary_list, n_list, common = _make_reasonable_filtering_case()
+
+    if method == "rss":
+        baseline = MultiSuSiE.multisusie_rss(
+            b_list=[b.copy() for b in b_list],
+            s_list=[s.copy() for s in s_list],
+            R_list=[r.copy() for r in r_list],
+            varY_list=vary_list,
+            population_sizes=n_list,
+            single_population_mac_thresh=0,
+            low_memory_mode=False,
+            recover_R=False,
+            min_abs_corr=0,
+            **common,
+        )
+    else:
+        baseline = MultiSuSiE.multisusie(
+            X_list=[x.copy() for x in x_list],
+            Y_list=[y.copy() for y in y_list],
+            standardize=False,
+            calculate_purity=True,
+            n_purity=10_000,
+            min_abs_corr=0,
+            **common,
+        )
+
+    baseline_purity = np.asarray(baseline.sets[1], dtype=float)
+    finite = baseline_purity[np.isfinite(baseline_purity)]
+    assert finite.size > 0
+    min_finite = float(np.min(finite))
+    assert 0 < min_finite < 1
+
+    threshold = min_finite + 0.05
+    assert 0 < threshold < 1
+
+    if method == "rss":
+        fit = MultiSuSiE.multisusie_rss(
+            b_list=[b.copy() for b in b_list],
+            s_list=[s.copy() for s in s_list],
+            R_list=[r.copy() for r in r_list],
+            varY_list=vary_list,
+            population_sizes=n_list,
+            single_population_mac_thresh=0,
+            low_memory_mode=False,
+            recover_R=False,
+            min_abs_corr=threshold,
+            **common,
+        )
+    else:
+        fit = MultiSuSiE.multisusie(
+            X_list=[x.copy() for x in x_list],
+            Y_list=[y.copy() for y in y_list],
+            standardize=False,
+            calculate_purity=True,
+            n_purity=10_000,
+            min_abs_corr=threshold,
+            **common,
+        )
+
+    purity = np.asarray(fit.sets[1], dtype=float)
+    include = np.asarray(fit.sets[3], dtype=bool)
+    finite = np.isfinite(purity)
+    assert np.any((~include) & finite)
+    assert np.all(include[finite] == (purity[finite] >= threshold))

--- a/tests/test_individual_edge_cases.py
+++ b/tests/test_individual_edge_cases.py
@@ -114,5 +114,7 @@ def test_individual_multisusie_mutates_x_when_low_memory_true():
         max_iter=60,
     )
 
-    any_changed = any(np.max(np.abs(before - after)) > 1e-10 for before, after in zip(x_before, x_in))
+    any_changed = any(
+        np.max(np.abs(before - after)) > 1e-10 for before, after in zip(x_before, x_in)
+    )
     assert any_changed

--- a/tests/test_individual_edge_cases.py
+++ b/tests/test_individual_edge_cases.py
@@ -92,38 +92,6 @@ def test_individual_input_shape_validation():
         )
 
 
-def test_individual_multisusie_does_not_mutate_caller_inputs_when_low_memory_false():
-    x_list, y_list = _make_two_pop_data(seed=17)
-    y_list[0][4] = np.nan
-
-    x_in = [x.copy() for x in x_list]
-    y_in = [y.copy() for y in y_list]
-    x_before = [x.copy() for x in x_in]
-    y_before = [y.copy() for y in y_in]
-
-    MultiSuSiE.multisusie(
-        X_list=x_in,
-        Y_list=y_in,
-        rho=np.eye(2),
-        L=4,
-        scaled_prior_variance=0.2,
-        standardize=True,
-        low_memory_mode=False,
-        min_abs_corr=0,
-        float_type=np.float64,
-        estimate_prior_method="EM",
-        pop_spec_effect_priors=False,
-        iter_before_zeroing_effects=0,
-        max_iter=60,
-    )
-
-    for before, after in zip(x_before, x_in):
-        np.testing.assert_allclose(before, after, rtol=0, atol=0)
-
-    for before, after in zip(y_before, y_in):
-        np.testing.assert_allclose(before, after, rtol=0, atol=0, equal_nan=True)
-
-
 def test_individual_multisusie_mutates_x_when_low_memory_true():
     x_list, y_list = _make_two_pop_data(seed=21)
     x_in = [x.copy() for x in x_list]

--- a/tests/test_individual_edge_cases.py
+++ b/tests/test_individual_edge_cases.py
@@ -73,7 +73,7 @@ def test_individual_input_shape_validation():
     x = np.random.default_rng(11).normal(size=(20, 4))
     y = np.random.default_rng(12).normal(size=20)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         MultiSuSiE.multisusie(
             X_list=[x, x],
             Y_list=[y],
@@ -82,7 +82,7 @@ def test_individual_input_shape_validation():
             min_abs_corr=0,
         )
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         MultiSuSiE.multisusie(
             X_list=[x],
             Y_list=[y[:-1]],

--- a/tests/test_individual_vs_rss_consistency.py
+++ b/tests/test_individual_vs_rss_consistency.py
@@ -11,7 +11,6 @@ def test_individual_matches_summary_statistics(synthetic_data):
         varY_list=synthetic_data.vary_list,
         population_sizes=synthetic_data.n_list,
         low_memory_mode=False,
-        recover_R=False,
         single_population_mac_thresh=0,
         **synthetic_data.common,
     )

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -18,7 +18,10 @@ def _minimal_inputs():
 
 def test_raises_if_both_z_and_b_s_are_provided():
     d = _minimal_inputs()
-    with pytest.raises(ValueError, match="provide either \\(b_list and s_list\\) or z_list, but not both"):
+    with pytest.raises(
+        ValueError,
+        match="provide either \\(b_list and s_list\\) or z_list, but not both",
+    ):
         MultiSuSiE.multisusie_rss(
             R_list=d["R_list"],
             population_sizes=d["population_sizes"],
@@ -31,7 +34,10 @@ def test_raises_if_both_z_and_b_s_are_provided():
 
 def test_raises_if_neither_z_nor_b_s_is_provided():
     d = _minimal_inputs()
-    with pytest.raises(ValueError, match="provide either \\(b_list and s_list\\) or z_list, but not both"):
+    with pytest.raises(
+        ValueError,
+        match="provide either \\(b_list and s_list\\) or z_list, but not both",
+    ):
         MultiSuSiE.multisusie_rss(
             R_list=d["R_list"],
             population_sizes=d["population_sizes"],
@@ -40,7 +46,10 @@ def test_raises_if_neither_z_nor_b_s_is_provided():
 
 def test_raises_if_b_without_s_or_vary():
     d = _minimal_inputs()
-    with pytest.raises(ValueError, match="if b_list is provided, s_list and varY_list must also be provided"):
+    with pytest.raises(
+        ValueError,
+        match="if b_list is provided, s_list and varY_list must also be provided",
+    ):
         MultiSuSiE.multisusie_rss(
             R_list=d["R_list"],
             population_sizes=d["population_sizes"],

--- a/tests/test_low_memory_behavior.py
+++ b/tests/test_low_memory_behavior.py
@@ -18,5 +18,8 @@ def test_low_memory_true_mutates_r_inputs(synthetic_data):
         **synthetic_data.common,
     )
 
-    any_changed = any(np.nanmax(np.abs(before - after)) > 1e-10 for before, after in zip(r_before, r_list))
+    any_changed = any(
+        np.nanmax(np.abs(before - after)) > 1e-10
+        for before, after in zip(r_before, r_list)
+    )
     assert any_changed

--- a/tests/test_low_memory_behavior.py
+++ b/tests/test_low_memory_behavior.py
@@ -3,35 +3,6 @@ import numpy as np
 import MultiSuSiE
 
 
-def test_low_memory_false_does_not_mutate_inputs(synthetic_data):
-    r_list_copy = [r.copy() for r in synthetic_data.r_list]
-    beta_hat_copy = [b.copy() for b in synthetic_data.beta_hat_list]
-    se_copy = [s.copy() for s in synthetic_data.se_list]
-
-    MultiSuSiE.multisusie_rss(
-        b_list=synthetic_data.beta_hat_list,
-        s_list=synthetic_data.se_list,
-        R_list=synthetic_data.r_list,
-        varY_list=synthetic_data.vary_list,
-        population_sizes=synthetic_data.n_list,
-        single_population_mac_thresh=5,
-        low_memory_mode=False,
-        **synthetic_data.common,
-    )
-
-    for r_before, r_after in zip(r_list_copy, synthetic_data.r_list):
-        assert np.nanmax(np.abs(r_before - r_after)) < 1e-10
-        assert (np.isnan(r_before) == np.isnan(r_after)).all()
-
-    for b_before, b_after in zip(beta_hat_copy, synthetic_data.beta_hat_list):
-        assert np.nanmax(np.abs(b_before - b_after)) < 1e-10
-        assert (np.isnan(b_before) == np.isnan(b_after)).all()
-
-    for s_before, s_after in zip(se_copy, synthetic_data.se_list):
-        assert np.nanmax(np.abs(s_before - s_after)) < 1e-10
-        assert (np.isnan(s_before) == np.isnan(s_after)).all()
-
-
 def test_low_memory_true_mutates_r_inputs(synthetic_data):
     r_list = [r.copy() for r in synthetic_data.r_list]
     r_before = [r.copy() for r in r_list]

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -12,7 +12,6 @@ def test_rss_output_shapes_and_attributes(synthetic_data):
         population_sizes=synthetic_data.n_list,
         single_population_mac_thresh=0,
         low_memory_mode=False,
-        recover_R=False,
         **synthetic_data.common,
     )
 
@@ -68,7 +67,6 @@ def test_variant_ids_are_propagated_to_credible_sets(synthetic_data):
         population_sizes=synthetic_data.n_list,
         single_population_mac_thresh=0,
         low_memory_mode=False,
-        recover_R=False,
         variant_ids=variant_ids,
         **synthetic_data.common,
     )

--- a/tests/test_recovery_utils.py
+++ b/tests/test_recovery_utils.py
@@ -25,9 +25,13 @@ def test_recover_r_from_xtx_roundtrip(synthetic_data):
 
 
 def test_recover_xtx_xty_from_z_matches_standardized_data(synthetic_data):
-    z_list = [b / s for b, s in zip(synthetic_data.beta_hat_list, synthetic_data.se_list)]
+    z_list = [
+        b / s for b, s in zip(synthetic_data.beta_hat_list, synthetic_data.se_list)
+    ]
     with np.errstate(divide="ignore", invalid="ignore"):
-        geno_std_list = [geno / np.std(geno, axis=0, ddof=1) for geno in synthetic_data.geno_list]
+        geno_std_list = [
+            geno / np.std(geno, axis=0, ddof=1) for geno in synthetic_data.geno_list
+        ]
     y_std_list = [y / np.std(y, ddof=1) for y in synthetic_data.y_list]
     xtx_std_list = [geno.T.dot(geno) for geno in geno_std_list]
     xty_std_list = [geno.T.dot(y) for geno, y in zip(geno_std_list, y_std_list)]

--- a/tests/test_rss_numerical_stability.py
+++ b/tests/test_rss_numerical_stability.py
@@ -12,14 +12,15 @@ def test_rss_float32_and_float64_are_close(synthetic_data):
         population_sizes=synthetic_data.n_list,
         single_population_mac_thresh=0,
         low_memory_mode=False,
-        recover_R=False,
         rho=synthetic_data.common["rho"],
         L=synthetic_data.common["L"],
         scaled_prior_variance=synthetic_data.common["scaled_prior_variance"],
         min_abs_corr=synthetic_data.common["min_abs_corr"],
         estimate_prior_method=synthetic_data.common["estimate_prior_method"],
         pop_spec_effect_priors=synthetic_data.common["pop_spec_effect_priors"],
-        iter_before_zeroing_effects=synthetic_data.common["iter_before_zeroing_effects"],
+        iter_before_zeroing_effects=synthetic_data.common[
+            "iter_before_zeroing_effects"
+        ],
     )
 
     fit64 = MultiSuSiE.multisusie_rss(float_type=np.float64, **base_kwargs)


### PR DESCRIPTION
## Summary
- Improve API/doc clarity around low-memory behavior and mutation semantics.
- Remove unsupported `recover_R` exposure from top-level `multisusie_rss`; keep behavior internal.
- Add CI quality gates for `ruff`, `black --check`, and `pytest`.
- Add local development check instructions to README.
- Apply Black formatting across source/tests and small readability cleanups (no algorithm changes).

## Validation
- `ruff check .`
- `black --check .`
- `pytest -q` (37 passed)